### PR TITLE
Cleaned up warnings and compile errors for Rust nightly

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -13,6 +13,7 @@ pub struct iovec {
     pub iov_base: *mut c_void,
     pub iov_len: size_t
 }
+impl Copy for iovec {}
 
 #[repr(C)]
 #[stable]
@@ -20,6 +21,7 @@ pub struct const_iovec {
     pub iov_base: *const c_void,
     pub iov_len: size_t
 }
+impl Copy for const_iovec {}
 
 #[stable]
 pub fn array_to_iovecs(args: &[&str]) -> Vec<const_iovec> {

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,6 +1,7 @@
 use libc::{c_int,size_t};
 use log::{Logger,LogRecord,LogLevel,LogLocation};
 use std::{fmt,io,ptr};
+use std::num::SignedInt;
 use std::collections::BTreeMap;
 use ffi;
 
@@ -15,7 +16,7 @@ pub fn send(args : &[&str]) -> c_int {
 
 /// Send a simple message to systemd.
 pub fn print(lvl : uint, s : &str) -> c_int {
-    send([
+    send(&[
          format!("PRIORITY={}", lvl).as_slice(),
          format!("MESSAGE={}", s).as_slice()
          ])
@@ -24,7 +25,7 @@ pub fn print(lvl : uint, s : &str) -> c_int {
 /// Send a `log::LogRecord` to systemd.
 pub fn log_(record: &LogRecord) {
     let LogLevel(lvl) = record.level;
-    send([format!("PRIORITY={}", lvl).as_slice(),
+    send(&[format!("PRIORITY={}", lvl).as_slice(),
     format!("MESSAGE={}", record.args).as_slice(),
     format!("CODE_LINE={}", record.line).as_slice(),
     format!("CODE_FILE={}", record.file).as_slice(),
@@ -49,6 +50,7 @@ impl Logger for JournalLogger {
         log_(record);
     }
 }
+impl Copy for JournalLogger {}
 
 #[experimental]
 pub type JournalRecord = BTreeMap<String, String>;
@@ -70,6 +72,8 @@ pub enum JournalFiles {
     /// Both the system-wide journal and the current user's journal.
     All
 }
+
+impl Copy for JournalFiles {}
 
 impl Journal {
     /// Open the systemd journal for reading.
@@ -93,9 +97,9 @@ impl Journal {
             flags |= ffi::SD_JOURNAL_LOCAL_ONLY;
         }
         flags |= match files {
-            System => ffi::SD_JOURNAL_SYSTEM,
-            CurrentUser => ffi::SD_JOURNAL_CURRENT_USER,
-            All => 0
+            JournalFiles::System => ffi::SD_JOURNAL_SYSTEM,
+            JournalFiles::CurrentUser => ffi::SD_JOURNAL_CURRENT_USER,
+            JournalFiles::All => 0
         };
 
         let journal = Journal { j: ptr::null_mut() };
@@ -123,11 +127,13 @@ impl Journal {
         while sd_try!(ffi::sd_journal_enumerate_data(self.j, &data, &mut sz)) > 0 {
             unsafe {
                 ::collections::slice::raw::mut_buf_as_slice(data, sz as uint, |b| {
-                    let field = ::std::str::raw::from_utf8(b);
-                    let name_value = field.splitn(1, '=');
+                    let field = ::std::str::from_utf8_unchecked(b);
+                    let mut name_value = field.splitn(1, '=');
+                    let name = name_value.next().unwrap();
+                    let value = name_value.next().unwrap();
                     ret.insert(
-                        String::from_str(name_value.next()),
-                        String::from_str(name_value.next()));
+                        String::from_str(name),
+                        String::from_str(value));
                 });
             }
         }

--- a/tests/journal.rs
+++ b/tests/journal.rs
@@ -7,7 +7,7 @@
 fn test() {
     use log::{set_logger};
     use systemd::journal;
-    journal::send(["CODE_FILE=HI", "CODE_LINE=1213", "CODE_FUNCTION=LIES"]);
+    journal::send(&["CODE_FILE=HI", "CODE_LINE=1213", "CODE_FUNCTION=LIES"]);
     journal::print(1, format!("Rust can talk to the journal: {}",
                               4i).as_slice());
     set_logger(box journal::JournalLogger);


### PR DESCRIPTION
I'm working on adding sd-daemon support, but I'm building with Rust nightly. These are some preliminary changes to make the project buildable and runnable with the current compiler.
