### PR TITLE
Run rustfmt + fix long line length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /Cargo.lock
+
+*.bk

--- a/libsystemd-sys/src/bus/mod.rs
+++ b/libsystemd-sys/src/bus/mod.rs
@@ -1,4 +1,4 @@
-use super::{c_char,c_int,c_void,uid_t,gid_t,pid_t,size_t,c_uint};
+use super::{c_char, c_int, c_void, uid_t, gid_t, pid_t, size_t, c_uint};
 use super::id128::sd_id128_t;
 use super::const_iovec;
 use super::event::sd_event;
@@ -13,50 +13,44 @@ pub type sd_bus_creds = c_void;
 pub type sd_bus_track = c_void;
 
 
-pub type sd_bus_message_handler_t =
-    Option<unsafe extern "C" fn(m: *mut sd_bus_message,
-                                userdata: *mut c_void,
-                                ret_error: *mut sd_bus_error)
-                              -> c_int>;
-pub type sd_bus_property_get_t =
-    Option<unsafe extern "C" fn(bus: *mut sd_bus,
-                                path: *const c_char,
-                                interface: *const c_char,
-                                property: *const c_char,
-                                reply: *mut sd_bus_message,
-                                userdata: *mut c_void,
-                                ret_error: *mut sd_bus_error)
-                              -> c_int>;
-pub type sd_bus_property_set_t =
-    Option<unsafe extern "C" fn(bus: *mut sd_bus,
-                                path: *const c_char,
-                                interface: *const c_char,
-                                property: *const c_char,
-                                value: *mut sd_bus_message,
-                                userdata: *mut c_void,
-                                ret_error: *mut sd_bus_error)
-                              -> c_int>;
-pub type sd_bus_object_find_t =
-    Option<unsafe extern "C" fn(bus: *mut sd_bus,
-                                path: *const c_char,
-                                interface: *const c_char,
-                                userdata: *mut c_void,
-                                ret_found: *mut *mut c_void,
-                                ret_error: *mut sd_bus_error)
-                              -> c_int>;
+pub type sd_bus_message_handler_t = Option<unsafe extern "C" fn(m: *mut sd_bus_message,
+                                                                userdata: *mut c_void,
+                                                                ret_error: *mut sd_bus_error)
+                                                                -> c_int>;
+pub type sd_bus_property_get_t = Option<unsafe extern "C" fn(bus: *mut sd_bus,
+                                                             path: *const c_char,
+                                                             interface: *const c_char,
+                                                             property: *const c_char,
+                                                             reply: *mut sd_bus_message,
+                                                             userdata: *mut c_void,
+                                                             ret_error: *mut sd_bus_error)
+                                                             -> c_int>;
+pub type sd_bus_property_set_t = Option<unsafe extern "C" fn(bus: *mut sd_bus,
+                                                             path: *const c_char,
+                                                             interface: *const c_char,
+                                                             property: *const c_char,
+                                                             value: *mut sd_bus_message,
+                                                             userdata: *mut c_void,
+                                                             ret_error: *mut sd_bus_error)
+                                                             -> c_int>;
+pub type sd_bus_object_find_t = Option<unsafe extern "C" fn(bus: *mut sd_bus,
+                                                            path: *const c_char,
+                                                            interface: *const c_char,
+                                                            userdata: *mut c_void,
+                                                            ret_found: *mut *mut c_void,
+                                                            ret_error: *mut sd_bus_error)
+                                                            -> c_int>;
 
-pub type sd_bus_node_enumerator_t =
-    Option<unsafe extern "C" fn(bus: *mut sd_bus,
-                                prefix: *const c_char,
-                                userdata: *mut c_void,
-                                ret_nodes: *mut *mut *mut c_char,
-                                ret_error: *mut sd_bus_error)
-                              -> c_int>;
+pub type sd_bus_node_enumerator_t = Option<unsafe extern "C" fn(bus: *mut sd_bus,
+                                                                prefix: *const c_char,
+                                                                userdata: *mut c_void,
+                                                                ret_nodes: *mut *mut *mut c_char,
+                                                                ret_error: *mut sd_bus_error)
+                                                                -> c_int>;
 
-pub type sd_bus_track_handler_t =
-    Option<unsafe extern "C" fn(track: *mut sd_bus_track,
-                                userdata: *mut c_void
-                            ) -> c_int>;
+pub type sd_bus_track_handler_t = Option<unsafe extern "C" fn(track: *mut sd_bus_track,
+                                                              userdata: *mut c_void)
+                                                              -> c_int>;
 
 #[repr(C)]
 pub struct sd_bus_error {
@@ -72,7 +66,7 @@ pub struct sd_bus_error_map {
 }
 
 extern "C" {
-    /* Connections */
+    // Connections
     pub fn sd_bus_default(ret: *mut *mut sd_bus) -> c_int;
     pub fn sd_bus_default_user(ret: *mut *mut sd_bus) -> c_int;
     pub fn sd_bus_default_system(ret: *mut *mut sd_bus) -> c_int;
@@ -87,7 +81,10 @@ extern "C" {
 
     pub fn sd_bus_set_address(bus: *mut sd_bus) -> c_int;
     pub fn sd_bus_set_fd(bus: *mut sd_bus) -> c_int;
-    pub fn sd_bus_set_exec(bus: *mut sd_bus, path: *const c_char, argv: *const *mut c_char) -> c_int;
+    pub fn sd_bus_set_exec(bus: *mut sd_bus,
+                           path: *const c_char,
+                           argv: *const *mut c_char)
+                           -> c_int;
     pub fn sd_bus_get_address(bus: *mut sd_bus, address: *mut *const c_char) -> c_int;
     pub fn sd_bus_set_bus_client(bus: *mut sd_bus, b: c_int) -> c_int;
     pub fn sd_bus_is_bus_client(bus: *mut sd_bus) -> c_int;
@@ -125,18 +122,39 @@ extern "C" {
     pub fn sd_bus_get_bus_id(bus: *mut sd_bus, id: *mut sd_id128_t) -> c_int;
     pub fn sd_bus_get_scope(bus: *mut sd_bus, scope: *mut *const c_char) -> c_int;
     pub fn sd_bus_get_tid(bus: *mut sd_bus, tid: *mut pid_t) -> c_int;
-    pub fn sd_bus_get_owner_creds(bus: *mut sd_bus, creds_mask: u64, ret: *mut *mut sd_bus_creds) -> c_int;
+    pub fn sd_bus_get_owner_creds(bus: *mut sd_bus,
+                                  creds_mask: u64,
+                                  ret: *mut *mut sd_bus_creds)
+                                  -> c_int;
 
-    pub fn sd_bus_send(bus: *mut sd_bus, m: *mut sd_bus_message, cookie : *mut u64) -> c_int;
-    pub fn sd_bus_send_to(bus: *mut sd_bus, m: *mut sd_bus_message, destination: *const c_char, cookie: *mut u64) -> c_int;
-    pub fn sd_bus_call(bus: *mut sd_bus, m: *mut sd_bus_message, usec: u64, ret_error: *mut sd_bus_error, reply: *mut *mut sd_bus_message) -> c_int;
-    pub fn sd_bus_call_async(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, m: *mut sd_bus_message, callback: sd_bus_message_handler_t, userdata: *mut c_void, usec: u64) -> c_int;
+    pub fn sd_bus_send(bus: *mut sd_bus, m: *mut sd_bus_message, cookie: *mut u64) -> c_int;
+    pub fn sd_bus_send_to(bus: *mut sd_bus,
+                          m: *mut sd_bus_message,
+                          destination: *const c_char,
+                          cookie: *mut u64)
+                          -> c_int;
+    pub fn sd_bus_call(bus: *mut sd_bus,
+                       m: *mut sd_bus_message,
+                       usec: u64,
+                       ret_error: *mut sd_bus_error,
+                       reply: *mut *mut sd_bus_message)
+                       -> c_int;
+    pub fn sd_bus_call_async(bus: *mut sd_bus,
+                             slot: *mut *mut sd_bus_slot,
+                             m: *mut sd_bus_message,
+                             callback: sd_bus_message_handler_t,
+                             userdata: *mut c_void,
+                             usec: u64)
+                             -> c_int;
 
     pub fn sd_bus_get_fd(bus: *mut sd_bus) -> c_int;
     pub fn sd_bus_get_events(bus: *mut sd_bus) -> c_int;
     pub fn sd_bus_get_timeout(bus: *mut sd_bus, timeout_usec: *mut u64) -> c_int;
     pub fn sd_bus_process(bus: *mut sd_bus, r: *mut *mut sd_bus_message) -> c_int;
-    pub fn sd_bus_process_priority(bus: *mut sd_bus, max_priority: i64, r: *mut *mut sd_bus_message) -> c_int;
+    pub fn sd_bus_process_priority(bus: *mut sd_bus,
+                                   max_priority: i64,
+                                   r: *mut *mut sd_bus_message)
+                                   -> c_int;
     pub fn sd_bus_wait(bus: *mut sd_bus, timeout_usec: u64) -> c_int;
     pub fn sd_bus_flush(bus: *mut sd_bus) -> c_int;
 
@@ -149,16 +167,56 @@ extern "C" {
     pub fn sd_bus_detach_event(bus: *mut sd_bus) -> c_int;
     pub fn sd_bus_get_event(bus: *mut sd_bus) -> *mut sd_event;
 
-    pub fn sd_bus_add_filter(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, callback: sd_bus_message_handler_t, userdata: *mut c_void) -> c_int;
-    pub fn sd_bus_add_match(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, match_: *const c_char, callback: sd_bus_message_handler_t, userdata: *mut c_void) -> c_int;
-    pub fn sd_bus_add_object(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, path: *const c_char, callback: sd_bus_message_handler_t, userdata: *mut c_void) -> c_int;
-    pub fn sd_bus_add_fallback(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, prefix: *const c_char, callback: sd_bus_message_handler_t, userdata: *mut c_void) -> c_int;
-    pub fn sd_bus_add_object_vtable(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, path: *const c_char, interface: *const c_char, vtable: *const sd_bus_vtable, userdata: *mut c_void) -> c_int;
-    pub fn sd_bus_add_fallback_vtable(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, prefix: *const c_char, interface: *const c_char, vtable: *const sd_bus_vtable, find: sd_bus_object_find_t, userdata: *mut c_void) -> c_int;
-    pub fn sd_bus_add_node_enumerator(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, path: *const c_char, callback: sd_bus_node_enumerator_t, userdata: *mut c_void) -> c_int;
-    pub fn sd_bus_add_object_manager(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, path: *const c_char) -> c_int;
+    pub fn sd_bus_add_filter(bus: *mut sd_bus,
+                             slot: *mut *mut sd_bus_slot,
+                             callback: sd_bus_message_handler_t,
+                             userdata: *mut c_void)
+                             -> c_int;
+    pub fn sd_bus_add_match(bus: *mut sd_bus,
+                            slot: *mut *mut sd_bus_slot,
+                            match_: *const c_char,
+                            callback: sd_bus_message_handler_t,
+                            userdata: *mut c_void)
+                            -> c_int;
+    pub fn sd_bus_add_object(bus: *mut sd_bus,
+                             slot: *mut *mut sd_bus_slot,
+                             path: *const c_char,
+                             callback: sd_bus_message_handler_t,
+                             userdata: *mut c_void)
+                             -> c_int;
+    pub fn sd_bus_add_fallback(bus: *mut sd_bus,
+                               slot: *mut *mut sd_bus_slot,
+                               prefix: *const c_char,
+                               callback: sd_bus_message_handler_t,
+                               userdata: *mut c_void)
+                               -> c_int;
+    pub fn sd_bus_add_object_vtable(bus: *mut sd_bus,
+                                    slot: *mut *mut sd_bus_slot,
+                                    path: *const c_char,
+                                    interface: *const c_char,
+                                    vtable: *const sd_bus_vtable,
+                                    userdata: *mut c_void)
+                                    -> c_int;
+    pub fn sd_bus_add_fallback_vtable(bus: *mut sd_bus,
+                                      slot: *mut *mut sd_bus_slot,
+                                      prefix: *const c_char,
+                                      interface: *const c_char,
+                                      vtable: *const sd_bus_vtable,
+                                      find: sd_bus_object_find_t,
+                                      userdata: *mut c_void)
+                                      -> c_int;
+    pub fn sd_bus_add_node_enumerator(bus: *mut sd_bus,
+                                      slot: *mut *mut sd_bus_slot,
+                                      path: *const c_char,
+                                      callback: sd_bus_node_enumerator_t,
+                                      userdata: *mut c_void)
+                                      -> c_int;
+    pub fn sd_bus_add_object_manager(bus: *mut sd_bus,
+                                     slot: *mut *mut sd_bus_slot,
+                                     path: *const c_char)
+                                     -> c_int;
 
-    /* Slot object */
+    // Slot object
 
     pub fn sd_bus_slot_ref(slot: *mut sd_bus_slot) -> *mut sd_bus_slot;
     pub fn sd_bus_slot_unref(slot: *mut sd_bus_slot) -> *mut sd_bus_slot;
@@ -166,22 +224,56 @@ extern "C" {
     pub fn sd_bus_slot_get_bus(slot: *mut sd_bus_slot) -> *mut sd_bus;
     pub fn sd_bus_slot_get_userdata(slot: *mut sd_bus_slot) -> *mut c_void;
     pub fn sd_bus_slot_set_userdata(slot: *mut sd_bus_slot, userdata: *mut c_void) -> *mut c_void;
-    pub fn sd_bus_slot_set_description(slot: *mut sd_bus_slot, description: *const c_char) -> c_int;
-    pub fn sd_bus_slot_get_description(slot: *mut sd_bus_slot, description: *mut *const c_char) -> c_int;
+    pub fn sd_bus_slot_set_description(slot: *mut sd_bus_slot,
+                                       description: *const c_char)
+                                       -> c_int;
+    pub fn sd_bus_slot_get_description(slot: *mut sd_bus_slot,
+                                       description: *mut *const c_char)
+                                       -> c_int;
 
     pub fn sd_bus_slot_get_current_message(slot: *mut sd_bus_slot) -> *mut sd_bus_message;
     pub fn sd_bus_slot_get_current_handler(bus: *mut sd_bus_slot) -> sd_bus_message_handler_t;
     pub fn sd_bus_slot_get_current_userdata(slot: *mut sd_bus_slot) -> *mut c_void;
 
-    /* Message object */
+    // Message object
 
-    pub fn sd_bus_message_new_signal(bus: *mut sd_bus, m: *mut *mut sd_bus_message, path: *const c_char, interface: *const c_char, member: *const c_char) -> c_int;
-    pub fn sd_bus_message_new_method_call(bus: *mut sd_bus, m: *mut *mut sd_bus_message, destination: *const c_char, path: *const c_char, interface: *const c_char, member: *const c_char) -> c_int;
-    pub fn sd_bus_message_new_method_return(call: *mut sd_bus_message, m: *mut *mut sd_bus_message) -> c_int;
-    pub fn sd_bus_message_new_method_error(call: *mut sd_bus_message, m: *mut *mut sd_bus_message, e: *const sd_bus_error) -> c_int;
-    pub fn sd_bus_message_new_method_errorf(call: *mut sd_bus_message, m: *mut *mut sd_bus_message, name: *const c_char, format: *const c_char, ...) -> c_int;
-    pub fn sd_bus_message_new_method_errno(call: *mut sd_bus_message, m: *mut *mut sd_bus_message, error: c_int, e: *const sd_bus_error) -> c_int;
-    pub fn sd_bus_message_new_method_errnof(call: *mut sd_bus_message, m: *mut *mut sd_bus_message, error: c_int, format: *const c_char, ...) -> c_int;
+    pub fn sd_bus_message_new_signal(bus: *mut sd_bus,
+                                     m: *mut *mut sd_bus_message,
+                                     path: *const c_char,
+                                     interface: *const c_char,
+                                     member: *const c_char)
+                                     -> c_int;
+    pub fn sd_bus_message_new_method_call(bus: *mut sd_bus,
+                                          m: *mut *mut sd_bus_message,
+                                          destination: *const c_char,
+                                          path: *const c_char,
+                                          interface: *const c_char,
+                                          member: *const c_char)
+                                          -> c_int;
+    pub fn sd_bus_message_new_method_return(call: *mut sd_bus_message,
+                                            m: *mut *mut sd_bus_message)
+                                            -> c_int;
+    pub fn sd_bus_message_new_method_error(call: *mut sd_bus_message,
+                                           m: *mut *mut sd_bus_message,
+                                           e: *const sd_bus_error)
+                                           -> c_int;
+    pub fn sd_bus_message_new_method_errorf(call: *mut sd_bus_message,
+                                            m: *mut *mut sd_bus_message,
+                                            name: *const c_char,
+                                            format: *const c_char,
+                                            ...)
+                                            -> c_int;
+    pub fn sd_bus_message_new_method_errno(call: *mut sd_bus_message,
+                                           m: *mut *mut sd_bus_message,
+                                           error: c_int,
+                                           e: *const sd_bus_error)
+                                           -> c_int;
+    pub fn sd_bus_message_new_method_errnof(call: *mut sd_bus_message,
+                                            m: *mut *mut sd_bus_message,
+                                            error: c_int,
+                                            format: *const c_char,
+                                            ...)
+                                            -> c_int;
 
     pub fn sd_bus_message_ref(m: *mut sd_bus_message) -> *mut sd_bus_message;
     pub fn sd_bus_message_unref(m: *mut sd_bus_message) -> *mut sd_bus_message;
@@ -209,90 +301,271 @@ extern "C" {
     pub fn sd_bus_message_get_seqnum(m: *mut sd_bus_message, seqnum: *mut u64) -> c_int;
 
     pub fn sd_bus_message_get_bus(m: *mut sd_bus_message) -> *mut sd_bus;
-    pub fn sd_bus_message_get_creds(m: *mut sd_bus_message) -> *mut sd_bus_creds; /* do not unref the result */
+    // do not unref the result
+    pub fn sd_bus_message_get_creds(m: *mut sd_bus_message) -> *mut sd_bus_creds;
 
-    pub fn sd_bus_message_is_signal(m: *mut sd_bus_message, interface: *const c_char, member: *const c_char) -> c_int;
-    pub fn sd_bus_message_is_method_call(m: *mut sd_bus_message, interface: *const c_char, member: *const c_char) -> c_int;
+    pub fn sd_bus_message_is_signal(m: *mut sd_bus_message,
+                                    interface: *const c_char,
+                                    member: *const c_char)
+                                    -> c_int;
+    pub fn sd_bus_message_is_method_call(m: *mut sd_bus_message,
+                                         interface: *const c_char,
+                                         member: *const c_char)
+                                         -> c_int;
     pub fn sd_bus_message_is_method_error(m: *mut sd_bus_message, name: *const c_char) -> c_int;
     pub fn sd_bus_message_is_empty(m: *mut sd_bus_message) -> c_int;
     pub fn sd_bus_message_has_signature(m: *mut sd_bus_message, signature: *const c_char) -> c_int;
 
     pub fn sd_bus_message_set_expect_reply(m: *mut sd_bus_message, b: c_int) -> c_int;
     pub fn sd_bus_message_set_auto_start(m: *mut sd_bus_message, b: c_int) -> c_int;
-    pub fn sd_bus_message_set_allow_interactive_authorization(m: *mut sd_bus_message, b: c_int) -> c_int;
+    pub fn sd_bus_message_set_allow_interactive_authorization(m: *mut sd_bus_message,
+                                                              b: c_int)
+                                                              -> c_int;
 
-    pub fn sd_bus_message_set_destination(m: *mut sd_bus_message, destination: *const c_char) -> c_int;
+    pub fn sd_bus_message_set_destination(m: *mut sd_bus_message,
+                                          destination: *const c_char)
+                                          -> c_int;
     pub fn sd_bus_message_set_priority(m: *mut sd_bus_message, priority: i64) -> c_int;
 
     pub fn sd_bus_message_append(m: *mut sd_bus_message, types: *const c_char, ...) -> c_int;
-    pub fn sd_bus_message_append_basic(m: *mut sd_bus_message, typ: c_char, p: *const c_void) -> c_int;
-    pub fn sd_bus_message_append_array(m: *mut sd_bus_message, typ: c_char, ptr: *const c_void, size: size_t) -> c_int;
-    pub fn sd_bus_message_append_array_space(m: *mut sd_bus_message, typ: c_char, size: size_t, ptr: *mut *mut c_void) -> c_int;
-    pub fn sd_bus_message_append_array_iovec(m: *mut sd_bus_message, typ: c_char, iov: *const const_iovec, n: c_uint) -> c_int;
-    pub fn sd_bus_message_append_array_memfd(m: *mut sd_bus_message, typ: c_char, memfd: c_int, offset: u64, size: u64) -> c_int;
-    pub fn sd_bus_message_append_string_space(m: *mut sd_bus_message, size: size_t, s: *mut *mut c_char) -> c_int;
-    pub fn sd_bus_message_append_string_iovec(m: *mut sd_bus_message, iov: *const const_iovec, n: c_uint) -> c_int;
-    pub fn sd_bus_message_append_string_memfd(m: *mut sd_bus_message, memfd: c_int, offset: u64, size: u64) -> c_int;
+    pub fn sd_bus_message_append_basic(m: *mut sd_bus_message,
+                                       typ: c_char,
+                                       p: *const c_void)
+                                       -> c_int;
+    pub fn sd_bus_message_append_array(m: *mut sd_bus_message,
+                                       typ: c_char,
+                                       ptr: *const c_void,
+                                       size: size_t)
+                                       -> c_int;
+    pub fn sd_bus_message_append_array_space(m: *mut sd_bus_message,
+                                             typ: c_char,
+                                             size: size_t,
+                                             ptr: *mut *mut c_void)
+                                             -> c_int;
+    pub fn sd_bus_message_append_array_iovec(m: *mut sd_bus_message,
+                                             typ: c_char,
+                                             iov: *const const_iovec,
+                                             n: c_uint)
+                                             -> c_int;
+    pub fn sd_bus_message_append_array_memfd(m: *mut sd_bus_message,
+                                             typ: c_char,
+                                             memfd: c_int,
+                                             offset: u64,
+                                             size: u64)
+                                             -> c_int;
+    pub fn sd_bus_message_append_string_space(m: *mut sd_bus_message,
+                                              size: size_t,
+                                              s: *mut *mut c_char)
+                                              -> c_int;
+    pub fn sd_bus_message_append_string_iovec(m: *mut sd_bus_message,
+                                              iov: *const const_iovec,
+                                              n: c_uint)
+                                              -> c_int;
+    pub fn sd_bus_message_append_string_memfd(m: *mut sd_bus_message,
+                                              memfd: c_int,
+                                              offset: u64,
+                                              size: u64)
+                                              -> c_int;
     pub fn sd_bus_message_append_strv(m: *mut sd_bus_message, l: *mut *mut c_char) -> c_int;
-    pub fn sd_bus_message_open_container(m: *mut sd_bus_message, typ: c_char, contents: *const c_char) -> c_int;
+    pub fn sd_bus_message_open_container(m: *mut sd_bus_message,
+                                         typ: c_char,
+                                         contents: *const c_char)
+                                         -> c_int;
     pub fn sd_bus_message_close_container(m: *mut sd_bus_message) -> c_int;
-    pub fn sd_bus_message_copy(m: *mut sd_bus_message, source: *mut sd_bus_message, all: c_int) -> c_int;
+    pub fn sd_bus_message_copy(m: *mut sd_bus_message,
+                               source: *mut sd_bus_message,
+                               all: c_int)
+                               -> c_int;
 
     pub fn sd_bus_message_read(m: *mut sd_bus_message, types: *const c_char, ...) -> c_int;
     pub fn sd_bus_message_read_basic(m: *mut sd_bus_message, typ: c_char, p: *mut c_void) -> c_int;
-    pub fn sd_bus_message_read_array(m: *mut sd_bus_message, typ: c_char, ptr: *mut *const c_void, size: *mut size_t) -> c_int;
-    pub fn sd_bus_message_read_strv(m: *mut sd_bus_message, l: *mut *mut *mut c_char) -> c_int; /* free the result! */
+    pub fn sd_bus_message_read_array(m: *mut sd_bus_message,
+                                     typ: c_char,
+                                     ptr: *mut *const c_void,
+                                     size: *mut size_t)
+                                     -> c_int;
+    // free the result!
+    pub fn sd_bus_message_read_strv(m: *mut sd_bus_message, l: *mut *mut *mut c_char) -> c_int;
     pub fn sd_bus_message_skip(m: *mut sd_bus_message, types: *const c_char) -> c_int;
-    pub fn sd_bus_message_enter_container(m: *mut sd_bus_message, typ: c_char, contents: *const c_char) -> c_int;
+    pub fn sd_bus_message_enter_container(m: *mut sd_bus_message,
+                                          typ: c_char,
+                                          contents: *const c_char)
+                                          -> c_int;
     pub fn sd_bus_message_exit_container(m: *mut sd_bus_message) -> c_int;
-    pub fn sd_bus_message_peek_type(m: *mut sd_bus_message, typ: *mut c_char, contents: *mut *const c_char) -> c_int;
-    pub fn sd_bus_message_verify_type(m: *mut sd_bus_message, typ: c_char, contents: *const c_char) -> c_int;
+    pub fn sd_bus_message_peek_type(m: *mut sd_bus_message,
+                                    typ: *mut c_char,
+                                    contents: *mut *const c_char)
+                                    -> c_int;
+    pub fn sd_bus_message_verify_type(m: *mut sd_bus_message,
+                                      typ: c_char,
+                                      contents: *const c_char)
+                                      -> c_int;
     pub fn sd_bus_message_at_end(m: *mut sd_bus_message, complete: c_int) -> c_int;
     pub fn sd_bus_message_rewind(m: *mut sd_bus_message, complete: c_int) -> c_int;
 
-    /* Bus management */
+    // Bus management
 
     pub fn sd_bus_get_unique_name(bus: *mut sd_bus, unique: *mut *const c_char) -> c_int;
     pub fn sd_bus_request_name(bus: *mut sd_bus, name: *const c_char, flags: u64) -> c_int;
     pub fn sd_bus_release_name(bus: *mut sd_bus, name: *const c_char) -> c_int;
-    pub fn sd_bus_list_names(bus: *mut sd_bus, acquired: *mut *mut *mut c_char, activatable: *mut *mut *mut c_char) -> c_int; /* free the results */
-    pub fn sd_bus_get_name_creds(bus: *mut sd_bus, name: *const c_char, mask: u64, creds: *mut *mut sd_bus_creds) -> c_int; /* unref the result! */
-    pub fn sd_bus_get_name_machine_id(bus: *mut sd_bus, name: *const c_char, machine: *mut sd_id128_t) -> c_int;
+    // free the results
+    pub fn sd_bus_list_names(bus: *mut sd_bus,
+                             acquired: *mut *mut *mut c_char,
+                             activatable: *mut *mut *mut c_char)
+                             -> c_int;
+    // unref the result!
+    pub fn sd_bus_get_name_creds(bus: *mut sd_bus,
+                                 name: *const c_char,
+                                 mask: u64,
+                                 creds: *mut *mut sd_bus_creds)
+                                 -> c_int;
+    pub fn sd_bus_get_name_machine_id(bus: *mut sd_bus,
+                                      name: *const c_char,
+                                      machine: *mut sd_id128_t)
+                                      -> c_int;
 
-    /* Convenience calls */
+    // Convenience calls
 
-    pub fn sd_bus_call_method(bus: *mut sd_bus, destination: *const c_char, path: *const c_char, interface: *const c_char, member: *const c_char, ret_error: *mut sd_bus_error, reply: *mut *mut sd_bus_message, types: *const c_char, ...) -> c_int;
-    pub fn sd_bus_call_method_async(bus: *mut sd_bus, slot: *mut *mut sd_bus_slot, destination: *const c_char, path: *const c_char, interface: *const c_char, member: *const c_char, callback: sd_bus_message_handler_t, userdata: *mut c_void, types: *const c_char, ...) -> c_int;
-    pub fn sd_bus_get_property(bus: *mut sd_bus, destination: *const c_char, path: *const c_char, interface: *const c_char, member: *const c_char, ret_error: *mut sd_bus_error, reply: *mut *mut sd_bus_message, typ: *const c_char) -> c_int;
-    pub fn sd_bus_get_property_trivial(bus: *mut sd_bus, destination: *const c_char, path: *const c_char, interface: *const c_char, member: *const c_char, ret_error: *mut sd_bus_error, typ: c_char, ret_ptr: *mut c_void) -> c_int;
-    pub fn sd_bus_get_property_string(bus: *mut sd_bus, destination: *const c_char, path: *const c_char, interface: *const c_char, member: *const c_char, ret_error: *mut sd_bus_error, ret: *mut *mut c_char) -> c_int; /* free the result! */
-    pub fn sd_bus_get_property_strv(bus: *mut sd_bus, destination: *const c_char, path: *const c_char, interface: *const c_char, member: *const c_char, ret_error: *mut sd_bus_error, ret: *mut *mut *mut c_char) -> c_int; /* free the result! */
-    pub fn sd_bus_set_property(bus: *mut sd_bus, destination: *const c_char, path: *const c_char, interface: *const c_char, member: *const c_char, ret_error: *mut sd_bus_error, typ: *const c_char, ...) -> c_int;
+    pub fn sd_bus_call_method(bus: *mut sd_bus,
+                              destination: *const c_char,
+                              path: *const c_char,
+                              interface: *const c_char,
+                              member: *const c_char,
+                              ret_error: *mut sd_bus_error,
+                              reply: *mut *mut sd_bus_message,
+                              types: *const c_char,
+                              ...)
+                              -> c_int;
+    pub fn sd_bus_call_method_async(bus: *mut sd_bus,
+                                    slot: *mut *mut sd_bus_slot,
+                                    destination: *const c_char,
+                                    path: *const c_char,
+                                    interface: *const c_char,
+                                    member: *const c_char,
+                                    callback: sd_bus_message_handler_t,
+                                    userdata: *mut c_void,
+                                    types: *const c_char,
+                                    ...)
+                                    -> c_int;
+    pub fn sd_bus_get_property(bus: *mut sd_bus,
+                               destination: *const c_char,
+                               path: *const c_char,
+                               interface: *const c_char,
+                               member: *const c_char,
+                               ret_error: *mut sd_bus_error,
+                               reply: *mut *mut sd_bus_message,
+                               typ: *const c_char)
+                               -> c_int;
+    pub fn sd_bus_get_property_trivial(bus: *mut sd_bus,
+                                       destination: *const c_char,
+                                       path: *const c_char,
+                                       interface: *const c_char,
+                                       member: *const c_char,
+                                       ret_error: *mut sd_bus_error,
+                                       typ: c_char,
+                                       ret_ptr: *mut c_void)
+                                       -> c_int;
+    // free the result!
+    pub fn sd_bus_get_property_string(bus: *mut sd_bus,
+                                      destination: *const c_char,
+                                      path: *const c_char,
+                                      interface: *const c_char,
+                                      member: *const c_char,
+                                      ret_error: *mut sd_bus_error,
+                                      ret: *mut *mut c_char)
+                                      -> c_int;
+    // free the result!
+    pub fn sd_bus_get_property_strv(bus: *mut sd_bus,
+                                    destination: *const c_char,
+                                    path: *const c_char,
+                                    interface: *const c_char,
+                                    member: *const c_char,
+                                    ret_error: *mut sd_bus_error,
+                                    ret: *mut *mut *mut c_char)
+                                    -> c_int;
+    pub fn sd_bus_set_property(bus: *mut sd_bus,
+                               destination: *const c_char,
+                               path: *const c_char,
+                               interface: *const c_char,
+                               member: *const c_char,
+                               ret_error: *mut sd_bus_error,
+                               typ: *const c_char,
+                               ...)
+                               -> c_int;
 
-    pub fn sd_bus_reply_method_return(call: *mut sd_bus_message, types: *const c_char, ...) -> c_int;
+    pub fn sd_bus_reply_method_return(call: *mut sd_bus_message,
+                                      types: *const c_char,
+                                      ...)
+                                      -> c_int;
     pub fn sd_bus_reply_method_error(call: *mut sd_bus_message, e: *const sd_bus_error) -> c_int;
-    pub fn sd_bus_reply_method_errorf(call: *mut sd_bus_message, name: *const c_char, format: *const c_char, ...) -> c_int;
-    pub fn sd_bus_reply_method_errno(call: *mut sd_bus_message, error: c_int, e: *const sd_bus_error) -> c_int;
-    pub fn sd_bus_reply_method_errnof(call: *mut sd_bus_message, error: c_int, format: *const c_char, ...) -> c_int;
+    pub fn sd_bus_reply_method_errorf(call: *mut sd_bus_message,
+                                      name: *const c_char,
+                                      format: *const c_char,
+                                      ...)
+                                      -> c_int;
+    pub fn sd_bus_reply_method_errno(call: *mut sd_bus_message,
+                                     error: c_int,
+                                     e: *const sd_bus_error)
+                                     -> c_int;
+    pub fn sd_bus_reply_method_errnof(call: *mut sd_bus_message,
+                                      error: c_int,
+                                      format: *const c_char,
+                                      ...)
+                                      -> c_int;
 
-    pub fn sd_bus_emit_signal(bus: *mut sd_bus, path: *const c_char, interface: *const c_char, member: *const c_char, types: *const c_char, ...) -> c_int;
+    pub fn sd_bus_emit_signal(bus: *mut sd_bus,
+                              path: *const c_char,
+                              interface: *const c_char,
+                              member: *const c_char,
+                              types: *const c_char,
+                              ...)
+                              -> c_int;
 
-    pub fn sd_bus_emit_properties_changed_strv(bus: *mut sd_bus, path: *const c_char, interface: *const c_char, names: *mut *mut c_char) -> c_int;
-    pub fn sd_bus_emit_properties_changed(bus: *mut sd_bus, path: *const c_char, interface: *const c_char, name: *const c_char, ...) -> c_int;
+    pub fn sd_bus_emit_properties_changed_strv(bus: *mut sd_bus,
+                                               path: *const c_char,
+                                               interface: *const c_char,
+                                               names: *mut *mut c_char)
+                                               -> c_int;
+    pub fn sd_bus_emit_properties_changed(bus: *mut sd_bus,
+                                          path: *const c_char,
+                                          interface: *const c_char,
+                                          name: *const c_char,
+                                          ...)
+                                          -> c_int;
 
     pub fn sd_bus_emit_object_added(bus: *mut sd_bus, path: *const c_char) -> c_int;
     pub fn sd_bus_emit_object_removed(bus: *mut sd_bus, path: *const c_char) -> c_int;
-    pub fn sd_bus_emit_interfaces_added_strv(bus: *mut sd_bus, path: *const c_char, interfaces: *mut *mut c_char) -> c_int;
-    pub fn sd_bus_emit_interfaces_added(bus: *mut sd_bus, path: *const c_char, interface: *const c_char, ...) -> c_int;
-    pub fn sd_bus_emit_interfaces_removed_strv(bus: *mut sd_bus, path: *const c_char, interfaces: *mut *mut c_char) -> c_int;
-    pub fn sd_bus_emit_interfaces_removed(bus: *mut sd_bus, path: *const c_char, interface: *const c_char, ...) -> c_int;
+    pub fn sd_bus_emit_interfaces_added_strv(bus: *mut sd_bus,
+                                             path: *const c_char,
+                                             interfaces: *mut *mut c_char)
+                                             -> c_int;
+    pub fn sd_bus_emit_interfaces_added(bus: *mut sd_bus,
+                                        path: *const c_char,
+                                        interface: *const c_char,
+                                        ...)
+                                        -> c_int;
+    pub fn sd_bus_emit_interfaces_removed_strv(bus: *mut sd_bus,
+                                               path: *const c_char,
+                                               interfaces: *mut *mut c_char)
+                                               -> c_int;
+    pub fn sd_bus_emit_interfaces_removed(bus: *mut sd_bus,
+                                          path: *const c_char,
+                                          interface: *const c_char,
+                                          ...)
+                                          -> c_int;
 
-    pub fn sd_bus_query_sender_creds(call: *mut sd_bus_message, mask: u64, creds: *mut *mut sd_bus_creds) -> c_int;
+    pub fn sd_bus_query_sender_creds(call: *mut sd_bus_message,
+                                     mask: u64,
+                                     creds: *mut *mut sd_bus_creds)
+                                     -> c_int;
     pub fn sd_bus_query_sender_privilege(call: *mut sd_bus_message, capability: c_int) -> c_int;
 
-    /* Credential handling */
+    // Credential handling
 
-    pub fn sd_bus_creds_new_from_pid(ret: *mut *mut sd_bus_creds, pid: pid_t, creds_mask: u64) -> c_int;
+    pub fn sd_bus_creds_new_from_pid(ret: *mut *mut sd_bus_creds,
+                                     pid: pid_t,
+                                     creds_mask: u64)
+                                     -> c_int;
     pub fn sd_bus_creds_ref(c: *mut sd_bus_creds) -> *mut sd_bus_creds;
     pub fn sd_bus_creds_unref(c: *mut sd_bus_creds) -> *mut sd_bus_creds;
     pub fn sd_bus_creds_get_mask(c: *const sd_bus_creds) -> u64;
@@ -309,7 +582,9 @@ extern "C" {
     pub fn sd_bus_creds_get_egid(c: *mut sd_bus_creds, egid: *mut gid_t) -> c_int;
     pub fn sd_bus_creds_get_sgid(c: *mut sd_bus_creds, sgid: *mut gid_t) -> c_int;
     pub fn sd_bus_creds_get_fsgid(c: *mut sd_bus_creds, fsgid: *mut gid_t) -> c_int;
-    pub fn sd_bus_creds_get_supplementary_gids(c: *mut sd_bus_creds, gids: *const *mut gid_t) -> c_int;
+    pub fn sd_bus_creds_get_supplementary_gids(c: *mut sd_bus_creds,
+                                               gids: *const *mut gid_t)
+                                               -> c_int;
     pub fn sd_bus_creds_get_comm(c: *mut sd_bus_creds, comm: *mut *const c_char) -> c_int;
     pub fn sd_bus_creds_get_tid_comm(c: *mut sd_bus_creds, comm: *mut *const c_char) -> c_int;
     pub fn sd_bus_creds_get_exe(c: *mut sd_bus_creds, exe: *mut *const c_char) -> c_int;
@@ -325,23 +600,41 @@ extern "C" {
     pub fn sd_bus_creds_has_permitted_cap(c: *mut sd_bus_creds, capability: c_int) -> c_int;
     pub fn sd_bus_creds_has_inheritable_cap(c: *mut sd_bus_creds, capability: c_int) -> c_int;
     pub fn sd_bus_creds_has_bounding_cap(c: *mut sd_bus_creds, capability: c_int) -> c_int;
-    pub fn sd_bus_creds_get_selinux_context(c: *mut sd_bus_creds, context: *mut *const c_char) -> c_int;
+    pub fn sd_bus_creds_get_selinux_context(c: *mut sd_bus_creds,
+                                            context: *mut *const c_char)
+                                            -> c_int;
     pub fn sd_bus_creds_get_audit_session_id(c: *mut sd_bus_creds, sessionid: *mut u32) -> c_int;
     pub fn sd_bus_creds_get_audit_login_uid(c: *mut sd_bus_creds, loginuid: *mut uid_t) -> c_int;
     pub fn sd_bus_creds_get_tty(c: *mut sd_bus_creds, tty: *mut *const c_char) -> c_int;
     pub fn sd_bus_creds_get_unique_name(c: *mut sd_bus_creds, name: *mut *const c_char) -> c_int;
-    pub fn sd_bus_creds_get_well_known_names(c: *mut sd_bus_creds, names: *mut *mut *mut c_char) -> c_int;
+    pub fn sd_bus_creds_get_well_known_names(c: *mut sd_bus_creds,
+                                             names: *mut *mut *mut c_char)
+                                             -> c_int;
     pub fn sd_bus_creds_get_description(c: *mut sd_bus_creds, name: *mut *const c_char) -> c_int;
 
-    /* Error structures */
+    // Error structures
 
     pub fn sd_bus_error_free(e: *mut sd_bus_error);
-    pub fn sd_bus_error_set(e: *mut sd_bus_error, name: *const c_char, message: *const c_char) -> c_int;
-    pub fn sd_bus_error_setf(e: *mut sd_bus_error, name: *const c_char, format: *const c_char, ...) -> c_int;
-    pub fn sd_bus_error_set_const(e: *mut sd_bus_error, name: *const c_char, message: *const c_char) -> c_int;
+    pub fn sd_bus_error_set(e: *mut sd_bus_error,
+                            name: *const c_char,
+                            message: *const c_char)
+                            -> c_int;
+    pub fn sd_bus_error_setf(e: *mut sd_bus_error,
+                             name: *const c_char,
+                             format: *const c_char,
+                             ...)
+                             -> c_int;
+    pub fn sd_bus_error_set_const(e: *mut sd_bus_error,
+                                  name: *const c_char,
+                                  message: *const c_char)
+                                  -> c_int;
     pub fn sd_bus_error_set_errno(e: *mut sd_bus_error, error: c_int) -> c_int;
-    pub fn sd_bus_error_set_errnof(e: *mut sd_bus_error, error: c_int, format: *const c_char, ...) -> c_int;
-    //pub fn sd_bus_error_set_errnofv(e: *mut sd_bus_error, error: c_int, format: *const c_char, va_list ap) _sd_printf_(3,0) -> c_int;
+    pub fn sd_bus_error_set_errnof(e: *mut sd_bus_error,
+                                   error: c_int,
+                                   format: *const c_char,
+                                   ...)
+                                   -> c_int;
+
     pub fn sd_bus_error_get_errno(e: *const sd_bus_error) -> c_int;
     pub fn sd_bus_error_copy(dest: *mut sd_bus_error, e: *const sd_bus_error) -> c_int;
     pub fn sd_bus_error_is_set(e: *const sd_bus_error) -> c_int;
@@ -349,22 +642,40 @@ extern "C" {
 
     pub fn sd_bus_error_add_map(map: *const sd_bus_error_map) -> c_int;
 
-    /* Label escaping */
+    // Label escaping
 
-    pub fn sd_bus_path_encode(prefix: *const c_char, external_id: *const c_char, ret_path: *mut *mut c_char) -> c_int;
-    pub fn sd_bus_path_encode_many(out: *mut *mut c_char, path_template: *const c_char, ...) -> c_int;
-    pub fn sd_bus_path_decode(path: *const c_char, prefix: *const c_char, ret_external_id: *mut *mut c_char) -> c_int;
-    pub fn sd_bus_path_decode_many(path: *const c_char, path_template: *const c_char, ...) -> c_int;
+    pub fn sd_bus_path_encode(prefix: *const c_char,
+                              external_id: *const c_char,
+                              ret_path: *mut *mut c_char)
+                              -> c_int;
+    pub fn sd_bus_path_encode_many(out: *mut *mut c_char,
+                                   path_template: *const c_char,
+                                   ...)
+                                   -> c_int;
+    pub fn sd_bus_path_decode(path: *const c_char,
+                              prefix: *const c_char,
+                              ret_external_id: *mut *mut c_char)
+                              -> c_int;
+    pub fn sd_bus_path_decode_many(path: *const c_char,
+                                   path_template: *const c_char,
+                                   ...)
+                                   -> c_int;
 
-    /* Tracking peers */
+    // Tracking peers
 
-    pub fn sd_bus_track_new(bus: *mut sd_bus, track: *mut *mut sd_bus_track, handler: sd_bus_track_handler_t, userdata: *mut c_void) -> c_int;
+    pub fn sd_bus_track_new(bus: *mut sd_bus,
+                            track: *mut *mut sd_bus_track,
+                            handler: sd_bus_track_handler_t,
+                            userdata: *mut c_void)
+                            -> c_int;
     pub fn sd_bus_track_ref(track: *mut sd_bus_track) -> *mut sd_bus_track;
     pub fn sd_bus_track_unref(track: *mut sd_bus_track) -> *mut sd_bus_track;
 
     pub fn sd_bus_track_get_bus(track: *mut sd_bus_track) -> *mut sd_bus;
     pub fn sd_bus_track_get_userdata(track: *mut sd_bus_track) -> *mut c_void;
-    pub fn sd_bus_track_set_userdata(track: *mut sd_bus_track, userdata: *mut c_void) -> *mut c_void;
+    pub fn sd_bus_track_set_userdata(track: *mut sd_bus_track,
+                                     userdata: *mut c_void)
+                                     -> *mut c_void;
 
     pub fn sd_bus_track_add_sender(track: *mut sd_bus_track, m: *mut sd_bus_message) -> c_int;
     pub fn sd_bus_track_remove_sender(track: *mut sd_bus_track, m: *mut sd_bus_message) -> c_int;

--- a/libsystemd-sys/src/bus/vtable.rs
+++ b/libsystemd-sys/src/bus/vtable.rs
@@ -1,9 +1,9 @@
 use std::mem::{transmute, zeroed};
 use std::default::Default;
 use super::super::{c_char, size_t};
-use super::{sd_bus_message_handler_t,sd_bus_property_get_t,sd_bus_property_set_t};
+use super::{sd_bus_message_handler_t, sd_bus_property_get_t, sd_bus_property_set_t};
 
-/* XXX: check this repr, might vary based on platform type sizes */
+// XXX: check this repr, might vary based on platform type sizes
 #[derive(Clone,Copy,Debug)]
 #[repr(u32)]
 pub enum SdBusVtableType {
@@ -12,7 +12,7 @@ pub enum SdBusVtableType {
     Method = 'M' as u32,
     Signal = 'S' as u32,
     Property = 'P' as u32,
-    WritableProperty = 'W' as u32
+    WritableProperty = 'W' as u32,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -26,29 +26,31 @@ pub enum SdBusVtableFlag {
     PropertyEmitsChange = 1 << 5,
     PropertyEmitsInvalidation = 1 << 6,
     PropertyExplicit = 1 << 7,
-    CapabilityMask = 0xFFFF << 40
+    CapabilityMask = 0xFFFF << 40,
 }
 
 #[derive(Clone, Debug)]
 #[repr(C)]
 pub struct sd_bus_vtable {
-    type_and_flags : u64,
-    /* NOTE: assumes that usize == pointer size == size_t */
-    union_data: [usize;5],
+    type_and_flags: u64,
+    // NOTE: assumes that usize == pointer size == size_t
+    union_data: [usize; 5],
 }
 
 impl Default for sd_bus_vtable {
-    fn default() -> Self { unsafe { zeroed() } }
+    fn default() -> Self {
+        unsafe { zeroed() }
+    }
 }
 
 impl sd_bus_vtable {
     pub fn type_and_flags(typ: u32, flags: u64) -> u64 {
-        let mut val = [0u8;8];
+        let mut val = [0u8; 8];
         assert!(typ <= ((1 << 8) - 1));
         assert!(flags <= ((1 << 56) - 1));
 
         val[0] = typ as u8;
-        let flags_raw : [u8;8] = unsafe { transmute(flags) };
+        let flags_raw: [u8; 8] = unsafe { transmute(flags) };
         for i in 0..7 {
             val[i + 1] = flags_raw[i];
         }
@@ -56,10 +58,9 @@ impl sd_bus_vtable {
         unsafe { transmute(val) }
     }
 
-    /*
-     * type & flags are stored in a bit field, the ordering of which might change depending on the
-     * platform.
-     */
+    // type & flags are stored in a bit field, the ordering of which might change depending on the
+    // platform.
+    //
     pub fn typ(&self) -> u32 {
         unsafe {
             let raw: *const u8 = &self.type_and_flags as *const _ as *const u8;
@@ -68,8 +69,8 @@ impl sd_bus_vtable {
     }
 
     pub fn flags(&self) -> u64 {
-        /* treat the first byte as 0 and the next 7 as their actual values */
-        let mut val = [0u8;8];
+        // treat the first byte as 0 and the next 7 as their actual values
+        let mut val = [0u8; 8];
         unsafe {
             let raw: *const u8 = transmute(&self.type_and_flags);
             for i in 1..8 {
@@ -82,7 +83,7 @@ impl sd_bus_vtable {
 
 #[test]
 fn vtable_bitfield() {
-    let mut b : sd_bus_vtable = Default::default();
+    let mut b: sd_bus_vtable = Default::default();
 
     b.type_and_flags = sd_bus_vtable::type_and_flags(0xAA, 0xBBCCBB);
 
@@ -108,7 +109,7 @@ pub struct sd_bus_table_method {
     pub signature: *const c_char,
     pub result: *const c_char,
     pub handler: sd_bus_message_handler_t,
-    pub offset: size_t
+    pub offset: size_t,
 }
 
 #[repr(C)]

--- a/libsystemd-sys/src/daemon.rs
+++ b/libsystemd-sys/src/daemon.rs
@@ -1,12 +1,22 @@
-use super::{c_int,size_t,c_char,pid_t};
+use super::{c_int, size_t, c_char, pid_t};
 
-extern {
+extern "C" {
     pub fn sd_listen_fds(unset_environment: c_int) -> c_int;
     pub fn sd_is_fifo(fd: c_int, path: *const c_char) -> c_int;
     pub fn sd_is_special(fd: c_int, path: *const c_char) -> c_int;
     pub fn sd_is_socket(fd: c_int, family: c_int, sock_type: c_int, listening: c_int) -> c_int;
-    pub fn sd_is_socket_inet(fd: c_int, family: c_int, sock_type: c_int, listening: c_int, port: u16) -> c_int;
-    pub fn sd_is_socket_unix(fd: c_int, sock_type: c_int, listening: c_int, path: *const c_char, length: size_t) -> c_int;
+    pub fn sd_is_socket_inet(fd: c_int,
+                             family: c_int,
+                             sock_type: c_int,
+                             listening: c_int,
+                             port: u16)
+                             -> c_int;
+    pub fn sd_is_socket_unix(fd: c_int,
+                             sock_type: c_int,
+                             listening: c_int,
+                             path: *const c_char,
+                             length: size_t)
+                             -> c_int;
     pub fn sd_is_mq(fd: c_int, path: *const c_char) -> c_int;
     pub fn sd_notify(unset_environment: c_int, state: *const c_char) -> c_int;
     // skipping sd_*notifyf; ignoring format strings

--- a/libsystemd-sys/src/event.rs
+++ b/libsystemd-sys/src/event.rs
@@ -3,4 +3,4 @@ use super::c_void;
 pub type sd_event = c_void;
 pub type sd_event_source = c_void;
 
-/* TODO: fill in the remainder of the sd-event.h symbols */
+// TODO: fill in the remainder of the sd-event.h symbols

--- a/libsystemd-sys/src/id128.rs
+++ b/libsystemd-sys/src/id128.rs
@@ -2,16 +2,16 @@ use super::{c_char, c_int};
 
 #[repr(C)]
 pub struct sd_id128_t {
-    pub bytes: [u8;16]
+    pub bytes: [u8; 16],
 }
 
-pub const SD_ID128_STRING_MAX : usize = 33;
+pub const SD_ID128_STRING_MAX: usize = 33;
 
 extern "C" {
-    /* s: &[c_char;33] */
+    // s: &[c_char;33]
     pub fn sd_id128_to_string(id: sd_id128_t, s: *mut c_char) -> *mut c_char;
 
-    /* s: &[c_char;33] */
+    // s: &[c_char;33]
     pub fn sd_id128_from_string(s: *const c_char, ret: *mut sd_id128_t) -> c_int;
 
     pub fn sd_id128_randomize(ret: *mut sd_id128_t) -> c_int;

--- a/libsystemd-sys/src/lib.rs
+++ b/libsystemd-sys/src/lib.rs
@@ -10,40 +10,45 @@
 #![allow(non_camel_case_types)]
 
 extern crate libc;
-pub use libc::{size_t,pid_t,uid_t,gid_t};
-pub use std::os::raw::{c_char,c_int,c_void,c_uint};
+pub use libc::{size_t, pid_t, uid_t, gid_t};
+pub use std::os::raw::{c_char, c_int, c_void, c_uint};
 
-pub const SD_JOURNAL_LOCAL_ONLY:   c_int = 1;
+pub const SD_JOURNAL_LOCAL_ONLY: c_int = 1;
 pub const SD_JOURNAL_RUNTIME_ONLY: c_int = 2;
-pub const SD_JOURNAL_SYSTEM:       c_int = 4;
+pub const SD_JOURNAL_SYSTEM: c_int = 4;
 pub const SD_JOURNAL_CURRENT_USER: c_int = 8;
 
 #[repr(C)]
 pub struct iovec {
     pub iov_base: *mut c_void,
-    pub iov_len: size_t
+    pub iov_len: size_t,
 }
 
 #[repr(C)]
 pub struct const_iovec {
     pub iov_base: *const c_void,
-    pub iov_len: size_t
+    pub iov_len: size_t,
 }
 
 pub fn array_to_iovecs(args: &[&str]) -> Vec<const_iovec> {
-    args.iter().map(|d| {
-        const_iovec { iov_base: d.as_ptr() as *const c_void, iov_len: d.len() as size_t }
-    }).collect()
+    args.iter()
+        .map(|d| {
+            const_iovec {
+                iov_base: d.as_ptr() as *const c_void,
+                iov_len: d.len() as size_t,
+            }
+        })
+        .collect()
 }
 
 use id128::sd_id128_t;
 pub type sd_journal = *mut c_void;
 
-extern {
-    /* sd-journal */
-    pub fn sd_journal_sendv(iv : *const const_iovec, n : c_int) -> c_int;
-    /* There are a bunch of other send methods, but for rust it doesn't make sense to call them
-     * (we don't need to do c-style format strings) */
+extern "C" {
+    // sd-journal
+    pub fn sd_journal_sendv(iv: *const const_iovec, n: c_int) -> c_int;
+    // There are a bunch of other send methods, but for rust it doesn't make sense to call them
+    // (we don't need to do c-style format strings)
 
     pub fn sd_journal_open(ret: *const sd_journal, flags: c_int) -> c_int;
     pub fn sd_journal_close(j: sd_journal) -> ();
@@ -55,12 +60,19 @@ extern {
     pub fn sd_journal_next_skip(j: sd_journal, skip: u64) -> c_int;
 
     pub fn sd_journal_get_realtime_usec(j: sd_journal, ret: *const u64) -> c_int;
-    pub fn sd_journal_get_monotonic_usec(j: sd_journal, ret: *const u64, ret_boot_id: *const sd_id128_t) -> c_int;
+    pub fn sd_journal_get_monotonic_usec(j: sd_journal,
+                                         ret: *const u64,
+                                         ret_boot_id: *const sd_id128_t)
+                                         -> c_int;
 
     pub fn sd_journal_set_data_threshold(j: sd_journal, sz: size_t) -> c_int;
     pub fn sd_journal_get_data_threshold(j: sd_journal, sz: *mut size_t) -> c_int;
 
-    pub fn sd_journal_get_data(j: sd_journal, field: *const c_char, data: *const *mut u8, l: *mut size_t) -> c_int;
+    pub fn sd_journal_get_data(j: sd_journal,
+                               field: *const c_char,
+                               data: *const *mut u8,
+                               l: *mut size_t)
+                               -> c_int;
     pub fn sd_journal_enumerate_data(j: sd_journal, data: *const *mut u8, l: *mut size_t) -> c_int;
     pub fn sd_journal_restart_data(j: sd_journal) -> ();
 
@@ -78,13 +90,23 @@ extern {
     pub fn sd_journal_get_cursor(j: sd_journal, cursor: *const *mut c_char) -> c_int;
     pub fn sd_journal_test_cursor(j: sd_journal, cursor: *const c_char) -> c_int;
 
-    pub fn sd_journal_get_cutoff_realtime_usec(j: sd_journal, from: *mut u64, to: *mut u64) -> c_int;
-    pub fn sd_journal_get_cutoff_monotonic_usec(j: sd_journal, boot_id: sd_id128_t, from: *mut u64, to: *mut u64) -> c_int;
+    pub fn sd_journal_get_cutoff_realtime_usec(j: sd_journal,
+                                               from: *mut u64,
+                                               to: *mut u64)
+                                               -> c_int;
+    pub fn sd_journal_get_cutoff_monotonic_usec(j: sd_journal,
+                                                boot_id: sd_id128_t,
+                                                from: *mut u64,
+                                                to: *mut u64)
+                                                -> c_int;
 
     pub fn sd_journal_get_usage(j: sd_journal, bytes: *mut u64) -> c_int;
 
     pub fn sd_journal_query_unique(j: sd_journal, field: *const c_char) -> c_int;
-    pub fn sd_journal_enumerate_unique(j: sd_journal, data: *const *mut c_void, l: *mut size_t) -> c_int;
+    pub fn sd_journal_enumerate_unique(j: sd_journal,
+                                       data: *const *mut c_void,
+                                       l: *mut size_t)
+                                       -> c_int;
     pub fn sd_journal_restart_unique(j: sd_journal) -> ();
 
     pub fn sd_journal_get_fd(j: sd_journal) -> c_int;

--- a/src/bus/types.rs
+++ b/src/bus/types.rs
@@ -21,8 +21,8 @@
 
 use super::MessageRef;
 use super::super::ffi;
-use std::mem::{uninitialized};
-use ffi::{c_int,c_char};
+use std::mem::uninitialized;
+use ffi::{c_int, c_char};
 
 unsafe trait SdBusMessageDirect {
     fn dbus_type() -> u8;
@@ -36,52 +36,53 @@ trait ToSdBusMessage {
 }
 
 trait FromSdBusMessage {
-    fn from_message(m: &mut MessageRef) -> ::Result<Self>
-        where Self: Sized;
+    fn from_message(m: &mut MessageRef) -> ::Result<Self> where Self: Sized;
 }
 
 impl<T: SdBusMessageDirect> ToSdBusMessage for T {
     fn to_message(&self, m: &mut MessageRef) -> ::Result<()> {
-        sd_try!(ffi::bus::sd_bus_message_append_basic(m.as_mut_ptr(), T::dbus_type() as c_char, self as *const _ as *const _));
+        sd_try!(ffi::bus::sd_bus_message_append_basic(m.as_mut_ptr(),
+                                                      T::dbus_type() as c_char,
+                                                      self as *const _ as *const _));
         Ok(())
     }
 }
 
 impl<T: SdBusMessageDirect> FromSdBusMessage for T {
     fn from_message(m: &mut MessageRef) -> ::Result<Self> {
-        let mut v : Self = unsafe { uninitialized() };
-        sd_try!(ffi::bus::sd_bus_message_read_basic(m.as_mut_ptr(), T::dbus_type() as c_char, &mut v as *mut _ as *mut _));
+        let mut v: Self = unsafe { uninitialized() };
+        sd_try!(ffi::bus::sd_bus_message_read_basic(m.as_mut_ptr(),
+                                                    T::dbus_type() as c_char,
+                                                    &mut v as *mut _ as *mut _));
         Ok(v)
     }
 }
 
-/*
-macro_rules! msg_basic {
-    ($typ:ty $dbus_type:expr) => {
-        impl ToSdBusMessage for $typ {
-            fn to_message(&self, m: &mut MessageRef) -> ::systemd::Result<()> {
-                let c_type : [u8;2] = [ $dbus_type, '\0' ];
-                sd_try!(ffi::sd_bus_message_append(m, &c_type, self as *const _));
-                Ok(())
-            }
-        }
-
-        impl FromSdBusMessage for $typ {
-            fn from_message(m: &mut MessageRef) -> ::systemd::Result<Self> {
-                let c_type : [u8;2] = [ $dbus_type, '\0' ];
-                let v : Self = unsafe { uninitialized() };
-                sd_try!(ffi::sd_bus_message_read(m, &c_type, &v));
-                Ok(v)
-            }
-        }
-    }
-
-    ($typ:ty $dbus_type:expr , $($rest:tt)* ) => {
-        msg_basic!($typ $dbus_type);
-        msg_basic!($($rest)*);
-    }
-}
-*/
+// macro_rules! msg_basic {
+//     ($typ:ty $dbus_type:expr) => {
+//         impl ToSdBusMessage for $typ {
+//             fn to_message(&self, m: &mut MessageRef) -> ::systemd::Result<()> {
+//                 let c_type : [u8;2] = [ $dbus_type, '\0' ];
+//                 sd_try!(ffi::sd_bus_message_append(m, &c_type, self as *const _));
+//                 Ok(())
+//             }
+//         }
+//
+//         impl FromSdBusMessage for $typ {
+//             fn from_message(m: &mut MessageRef) -> ::systemd::Result<Self> {
+//                 let c_type : [u8;2] = [ $dbus_type, '\0' ];
+//                 let v : Self = unsafe { uninitialized() };
+//                 sd_try!(ffi::sd_bus_message_read(m, &c_type, &v));
+//                 Ok(v)
+//             }
+//         }
+//     }
+//
+//     ($typ:ty $dbus_type:expr , $($rest:tt)* ) => {
+//         msg_basic!($typ $dbus_type);
+//         msg_basic!($($rest)*);
+//     }
+// }
 
 macro_rules! msg_basic {
     ($typ:ty : $dbus_type:expr) => {
@@ -110,16 +111,24 @@ msg_basic!{
 
 impl ToSdBusMessage for bool {
     fn to_message(&self, m: &mut MessageRef) -> ::Result<()> {
-        let i : c_int = if *self { 1 } else { 0 };
-        sd_try!(ffi::bus::sd_bus_message_append_basic(m.as_mut_ptr(), b'b' as c_char, &i as *const _ as *const _));
+        let i: c_int = if *self {
+            1
+        } else {
+            0
+        };
+        sd_try!(ffi::bus::sd_bus_message_append_basic(m.as_mut_ptr(),
+                                                      b'b' as c_char,
+                                                      &i as *const _ as *const _));
         Ok(())
     }
 }
 
 impl FromSdBusMessage for bool {
     fn from_message(m: &mut MessageRef) -> ::Result<Self> {
-        let mut i : c_int = unsafe { uninitialized() };
-        sd_try!(ffi::bus::sd_bus_message_read_basic(m.as_mut_ptr(), b'b' as c_char, &mut i as *mut _ as *mut _));
+        let mut i: c_int = unsafe { uninitialized() };
+        sd_try!(ffi::bus::sd_bus_message_read_basic(m.as_mut_ptr(),
+                                                    b'b' as c_char,
+                                                    &mut i as *mut _ as *mut _));
         Ok(i != 0)
     }
 }
@@ -128,23 +137,29 @@ pub struct UnixFd(pub c_int);
 
 impl ToSdBusMessage for UnixFd {
     fn to_message(&self, m: &mut MessageRef) -> ::Result<()> {
-        let i : c_int = self.0;
-        sd_try!(ffi::bus::sd_bus_message_append_basic(m.as_mut_ptr(), b'h' as c_char, &i as *const _ as *const _));
+        let i: c_int = self.0;
+        sd_try!(ffi::bus::sd_bus_message_append_basic(m.as_mut_ptr(),
+                                                      b'h' as c_char,
+                                                      &i as *const _ as *const _));
         Ok(())
     }
 }
 
 impl FromSdBusMessage for UnixFd {
     fn from_message(m: &mut MessageRef) -> ::Result<Self> {
-        let mut i : c_int = unsafe { uninitialized() };
-        sd_try!(ffi::bus::sd_bus_message_read_basic(m.as_mut_ptr(), b'h' as c_char, &mut i as *mut _ as *mut _));
+        let mut i: c_int = unsafe { uninitialized() };
+        sd_try!(ffi::bus::sd_bus_message_read_basic(m.as_mut_ptr(),
+                                                    b'h' as c_char,
+                                                    &mut i as *mut _ as *mut _));
         Ok(UnixFd(i))
     }
 }
 
 impl<'a> ToSdBusMessage for super::ObjectPath<'a> {
     fn to_message(&self, m: &mut MessageRef) -> ::Result<()> {
-        sd_try!(ffi::bus::sd_bus_message_append_basic(m.as_mut_ptr(), b'o' as c_char, self.as_ptr() as *const _));
+        sd_try!(ffi::bus::sd_bus_message_append_basic(m.as_mut_ptr(),
+                                                      b'o' as c_char,
+                                                      self.as_ptr() as *const _));
         Ok(())
     }
 }
@@ -156,17 +171,19 @@ impl<'a> ToSdBusMessage for super::ObjectPath<'a> {
 // If we could use &MessageRef instead this could be useful.
 impl<'a> FromSdBusMessage for super::ObjectPath<'a> {
     fn from_message(m: &mut MessageRef) -> ::Result<Self> {
-        let mut i : *const c_char = unsafe { uninitialized() };
-        sd_try!(ffi::bus::sd_bus_message_read_basic(m.as_mut_ptr(), b'o' as c_char, &mut i as *mut _ as *mut _));
-        Ok(unsafe {super::ObjectPath::from_ptr_unchecked(i)})
+        let mut i: *const c_char = unsafe { uninitialized() };
+        sd_try!(ffi::bus::sd_bus_message_read_basic(m.as_mut_ptr(),
+                                                    b'o' as c_char,
+                                                    &mut i as *mut _ as *mut _));
+        Ok(unsafe { super::ObjectPath::from_ptr_unchecked(i) })
     }
 }
 
 
-/* TODO:
- *  string-likes (string, object path, signature)
- *  array
- *  variant
- *  struct
- *  dict
- */
+// TODO:
+//  string-likes (string, object path, signature)
+//  array
+//  variant
+//  struct
+//  dict
+//

--- a/src/id128.rs
+++ b/src/id128.rs
@@ -5,7 +5,7 @@ use std::ffi::CStr;
 use super::Result;
 
 pub struct Id128 {
-    inner: ffi::id128::sd_id128_t
+    inner: ffi::id128::sd_id128_t,
 }
 
 impl fmt::Display for Id128 {
@@ -42,7 +42,7 @@ impl Id128 {
         Ok(r)
     }
 
-    pub fn as_bytes(&self) -> &[u8;16] {
+    pub fn as_bytes(&self) -> &[u8; 16] {
         &self.inner.bytes
     }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,6 +1,6 @@
-use libc::{c_int,size_t};
-use log::{self,Log,LogRecord,LogLocation,SetLoggerError};
-use std::{fmt,ptr,result};
+use libc::{c_int, size_t};
+use log::{self, Log, LogRecord, LogLocation, SetLoggerError};
+use std::{fmt, ptr, result};
 use std::collections::BTreeMap;
 use ffi;
 use super::Result;
@@ -9,17 +9,14 @@ use super::Result;
 ///
 /// This is a relatively low-level operation and probably not suitable unless
 /// you need precise control over which fields are sent to systemd.
-pub fn send(args : &[&str]) -> c_int {
+pub fn send(args: &[&str]) -> c_int {
     let iovecs = ffi::array_to_iovecs(args);
     unsafe { ffi::sd_journal_sendv(iovecs.as_ptr(), iovecs.len() as c_int) }
 }
 
 /// Send a simple message to systemd.
-pub fn print(lvl : u32, s : &str) -> c_int {
-    send(&[
-         &format!("PRIORITY={}", lvl),
-         &format!("MESSAGE={}", s)
-    ])
+pub fn print(lvl: u32, s: &str) -> c_int {
+    send(&[&format!("PRIORITY={}", lvl), &format!("MESSAGE={}", s)])
 }
 
 /// Send a `log::LogRecord` to systemd.
@@ -31,14 +28,12 @@ pub fn log_record(record: &LogRecord) {
     log(lvl, record.location(), record.args());
 }
 
-pub fn log(level: usize, loc: &LogLocation, args: &fmt::Arguments)
-{
+pub fn log(level: usize, loc: &LogLocation, args: &fmt::Arguments) {
     send(&[&format!("PRIORITY={}", level),
-        &format!("MESSAGE={}", args),
-        &format!("CODE_LINE={}", loc.line()),
-        &format!("CODE_FILE={}", loc.file()),
-        &format!("CODE_FUNCTION={}", loc.module_path()),
-    ]);
+           &format!("MESSAGE={}", args),
+           &format!("CODE_LINE={}", loc.line()),
+           &format!("CODE_FILE={}", loc.file()),
+           &format!("CODE_FUNCTION={}", loc.module_path())]);
 }
 
 pub struct JournalLog;
@@ -54,9 +49,7 @@ impl Log for JournalLog {
 
 impl JournalLog {
     pub fn init() -> result::Result<(), SetLoggerError> {
-        log::set_logger(|_max_log_level| {
-            Box::new(JournalLog)
-        })
+        log::set_logger(|_max_log_level| Box::new(JournalLog))
     }
 }
 
@@ -66,7 +59,7 @@ pub type JournalRecord = BTreeMap<String, String>;
 ///
 /// Supports read, next, previous, and seek operations.
 pub struct Journal {
-    j: ffi::sd_journal
+    j: ffi::sd_journal,
 }
 
 /// Represents the set of journal files to read.
@@ -76,7 +69,7 @@ pub enum JournalFiles {
     /// The current user's journal.
     CurrentUser,
     /// Both the system-wide journal and the current user's journal.
-    All
+    All,
 }
 
 impl Journal {
@@ -103,7 +96,7 @@ impl Journal {
         flags |= match files {
             JournalFiles::System => ffi::SD_JOURNAL_SYSTEM,
             JournalFiles::CurrentUser => ffi::SD_JOURNAL_CURRENT_USER,
-            JournalFiles::All => 0
+            JournalFiles::All => 0,
         };
 
         let journal = Journal { j: ptr::null_mut() };
@@ -148,4 +141,3 @@ impl Drop for Journal {
         }
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate libc;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate libsystemd_sys as ffi;
 pub use std::io::{Result, Error};
 
@@ -39,7 +40,8 @@ macro_rules! sd_try_unsafe {
 #[macro_export]
 macro_rules! char_or_null {
     ($e:expr) => (match $e {
-        Some(p) => ::std::ffi::CString::new(p.as_bytes()).unwrap().as_ptr() as *const ::libc::c_char,
+        Some(p) => ::std::ffi::CString::new(p.as_bytes()).unwrap()
+                                                         .as_ptr() as *const ::libc::c_char,
         None => ptr::null() as *const ::libc::c_char
     })
 }


### PR DESCRIPTION
Some commented code wasn't automatically fixed, handle that manually.  Also
move some comments for functions directly onto the function so gets into the
generated html.

I'm looking to make some cleanup changes and extend the library (especially around the journal, which I'm looking to use in a project).  Is there any roadmap?  Or any conventions that one should follow?  I figured I get this landed first so people using rustfmt have a place to start without making huge changes.