### PR TITLE
journal: implement seeking

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -129,7 +129,7 @@ impl Journal {
             unsafe {
                 let b = ::std::slice::from_raw_parts_mut(data, sz as usize);
                 let field = ::std::str::from_utf8_unchecked(b);
-                let mut name_value = field.splitn(1, '=');
+                let mut name_value = field.splitn(2, '=');
                 let name = name_value.next().unwrap();
                 let value = name_value.next().unwrap();
                 ret.insert(From::from(name), From::from(value));

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -1,9 +1,13 @@
-use libc::{c_int, size_t};
+use libc::{c_char, c_int, size_t};
 use log::{self, Log, LogRecord, LogLocation, LogLevelFilter, SetLoggerError};
-use std::{fmt, ptr, result};
+use std::{fmt, io, ptr, result};
 use std::collections::BTreeMap;
+use std::ffi::CString;
+use std::io::ErrorKind::InvalidData;
 use ffi::array_to_iovecs;
+use ffi::id128::sd_id128_t;
 use ffi::journal as ffi;
+use id128::Id128;
 use super::Result;
 
 /// Send preformatted fields to systemd.
@@ -83,6 +87,23 @@ pub enum JournalFiles {
     All,
 }
 
+/// Seeking position in journal.
+pub enum JournalSeek {
+    Head,
+    Current,
+    Tail,
+    ClockMonotonic {
+        boot_id: Id128,
+        usec: u64,
+    },
+    ClockRealtime {
+        usec: u64,
+    },
+    Cursor {
+        cursor: String,
+    },
+}
+
 impl Journal {
     /// Open the systemd journal for reading.
     ///
@@ -140,6 +161,37 @@ impl Journal {
         }
 
         Ok(Some(ret))
+    }
+
+    /// Seek to a specific position in journal. On success, returns a cursor
+    /// to the current entry.
+    pub fn seek(&self, seek: JournalSeek) -> Result<String> {
+        match seek {
+            JournalSeek::Head => sd_try!(ffi::sd_journal_seek_head(self.j)),
+            JournalSeek::Current => 0,
+            JournalSeek::Tail => sd_try!(ffi::sd_journal_seek_tail(self.j)),
+            JournalSeek::ClockMonotonic { boot_id, usec } => {
+                sd_try!(ffi::sd_journal_seek_monotonic_usec(self.j,
+                                                            sd_id128_t {
+                                                                bytes: *boot_id.as_bytes(),
+                                                            },
+                                                            usec))
+            }
+            JournalSeek::ClockRealtime { usec } => {
+                sd_try!(ffi::sd_journal_seek_realtime_usec(self.j, usec))
+            }
+            JournalSeek::Cursor { cursor } => {
+                sd_try!(ffi::sd_journal_seek_cursor(self.j, cursor.as_ptr() as *const c_char))
+            }
+        };
+        let c: *mut c_char = ptr::null_mut();
+        if unsafe { ffi::sd_journal_get_cursor(self.j, &c) != 0 } {
+            // Cursor may need to be re-aligned on a real entry first.
+            sd_try!(ffi::sd_journal_next(self.j));
+            sd_try!(ffi::sd_journal_get_cursor(self.j, &c));
+        }
+        let cs = unsafe { CString::from_raw(c) };
+        cs.into_string().or(Err(io::Error::new(InvalidData, "invalid cursor")))
     }
 }
 

--- a/tests/journal.rs
+++ b/tests/journal.rs
@@ -1,15 +1,36 @@
-#[macro_use] extern crate systemd;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate systemd;
+#[macro_use]
+extern crate log;
+
+use std::path::Path;
+use systemd::journal;
 
 #[test]
 fn test() {
-    use systemd::journal;
     journal::send(&["CODE_FILE=HI", "CODE_LINE=1213", "CODE_FUNCTION=LIES"]);
-    journal::print(1, &format!("Rust can talk to the journal: {}",
-                              4));
+    journal::print(1, &format!("Rust can talk to the journal: {}", 4));
 
     journal::JournalLog::init().ok().unwrap();
     log!(log::LogLevel::Info, "HI");
     sd_journal_log!(4, "HI {:?}", 2);
 }
 
+#[test]
+fn test_seek() {
+    let j = journal::Journal::open(journal::JournalFiles::All, false, false).unwrap();
+    if !Path::new("/run/systemd/journal/").exists() {
+        println!("missing journal files");
+        return;
+    }
+    log!(log::LogLevel::Info, "rust-systemd test_seek entry");
+    assert!(j.seek(journal::JournalSeek::Head).is_ok());
+    assert!(j.next_record().is_ok());
+    let c1 = j.seek(journal::JournalSeek::Current);
+    assert!(c1.is_ok());
+    let c2 = j.seek(journal::JournalSeek::Current);
+    assert!(c2.is_ok());
+    assert_eq!(c1.unwrap(), c2.unwrap());
+    assert!(j.seek(journal::JournalSeek::Tail).is_ok());
+    assert!(j.next_record().is_ok());
+}


### PR DESCRIPTION
This PR adds seeking capability to Journal, supporting multiple positioning specifiers (head, current, tail, cursor, monotonic-clock, realtime-clock). It also enhances rustdoc for the whole module.

In order to let the test pass, this also fixes message kv-splitting.
This conflicts with #6.