### PR TITLE
login: add support to retrieve unit identifier 

### DIFF
--- a/libsystemd-sys/src/lib.rs
+++ b/libsystemd-sys/src/lib.rs
@@ -16,6 +16,7 @@ pub mod id128;
 pub mod event;
 pub mod daemon;
 pub mod journal;
+pub mod login;
 
 #[repr(C)]
 pub struct iovec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,9 @@ pub mod daemon;
 /// sd-id128` for details
 pub mod id128;
 
+/// Interface to introspect on seats, sessions and users.
+pub mod login;
+
 /// An interface to work with the dbus message bus.
 ///
 /// WARNING: this is not complete. Right now we're missing:

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,0 +1,29 @@
+use std::ptr;
+use super::ffi::{c_char, pid_t};
+use ffi::login as ffi;
+use super::Result;
+use mbox::MString;
+
+/// Systemd unit types
+pub enum UnitType {
+    /// User service or scope unit
+    UserUnit,
+    /// System service or scope unit
+    SystemUnit,
+}
+
+/// Determines the systemd unit (i.e. service or scope unit) identifier of a process.
+///
+/// Specific processess can be targeted by optionally via PID. When no PID is
+/// specified, operation is executed for the calling process.
+/// This method can be used to retrieve either a system or an user unit identifier.
+pub fn get_unit(unit_type: UnitType, pid: Option<pid_t>) -> Result<String> {
+    let mut c_unit_name: *mut c_char = ptr::null_mut();
+    let p: pid_t = pid.unwrap_or(0);
+    match unit_type {
+        UnitType::UserUnit => sd_try!(ffi::sd_pid_get_user_unit(p, &mut c_unit_name)),
+        UnitType::SystemUnit => sd_try!(ffi::sd_pid_get_unit(p, &mut c_unit_name))
+    };
+    let unit_name = unsafe { MString::from_raw(c_unit_name) };
+    Ok(unit_name.unwrap().to_string())
+}

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -1,0 +1,19 @@
+extern crate systemd;
+
+use systemd::login;
+use systemd::daemon::booted;
+
+#[test]
+fn test_get_unit() {
+    let uu = login::get_unit(login::UnitType::UserUnit, None);
+    let su = login::get_unit(login::UnitType::SystemUnit, None);
+    let has_systemd = booted();
+    if has_systemd.is_ok() {
+        match has_systemd.unwrap() {
+            // This is not running in an unit at all
+            false => { assert!(uu.is_err()); assert!(su.is_err()); },
+            // This is either running in a system or in an user unit
+            true => { assert_eq!(uu.is_err(), su.is_ok()); },
+        };
+    }
+}


### PR DESCRIPTION
This commit export the `login` module in `libsystemd-sys`
and additionally introduces a new `login` module with
initial support for retrieving system/user unit information.