### PR TITLE
login: wrap some more getters

### DIFF
--- a/src/login.rs
+++ b/src/login.rs
@@ -57,3 +57,19 @@ pub fn get_machine_name(pid: Option<pid_t>) -> Result<String> {
     let machine_id = unsafe { MString::from_raw(c_machine_name) };
     Ok(machine_id.unwrap().to_string())
 }
+
+/// Determines the control group path of a process.
+///
+/// Specific processes can be optionally targeted via their PID. When no PID is
+/// specified, operation is executed for the calling process.
+/// This method can be used to retrieve the control group path of a specific
+/// process, relative to the root of the hierarchy. It returns the path without
+/// trailing slash, except for processes located in the root control group,
+/// where "/" is returned.
+pub fn get_cgroup(pid: Option<pid_t>) -> Result<String> {
+    let mut c_cgroup: *mut c_char = ptr::null_mut();
+    let p: pid_t = pid.unwrap_or(0);
+    sd_try!(ffi::sd_pid_get_cgroup(p, &mut c_cgroup));
+    let cg = unsafe { MString::from_raw(c_cgroup) };
+    Ok(cg.unwrap().to_string())
+}

--- a/src/login.rs
+++ b/src/login.rs
@@ -43,3 +43,17 @@ pub fn get_slice(slice_type: UnitType, pid: Option<pid_t>) -> Result<String> {
     let slice_id = unsafe { MString::from_raw(c_slice_name) };
     Ok(slice_id.unwrap().to_string())
 }
+
+/// Determines the machine name of a process.
+///
+/// Specific processes can be optionally targeted via their PID. When no PID is
+/// specified, operation is executed for the calling process.
+/// This method can be used to retrieve the machine name of processes running
+/// inside a VM or a container.
+pub fn get_machine_name(pid: Option<pid_t>) -> Result<String> {
+    let mut c_machine_name: *mut c_char = ptr::null_mut();
+    let p: pid_t = pid.unwrap_or(0);
+    sd_try!(ffi::sd_pid_get_machine_name(p, &mut c_machine_name));
+    let machine_id = unsafe { MString::from_raw(c_machine_name) };
+    Ok(machine_id.unwrap().to_string())
+}

--- a/src/login.rs
+++ b/src/login.rs
@@ -4,17 +4,17 @@ use ffi::login as ffi;
 use super::Result;
 use mbox::MString;
 
-/// Systemd unit types
+/// Systemd slice and unit types
 pub enum UnitType {
-    /// User service or scope unit
+    /// User slice, service or scope unit
     UserUnit,
-    /// System service or scope unit
+    /// System slice, service or scope unit
     SystemUnit,
 }
 
 /// Determines the systemd unit (i.e. service or scope unit) identifier of a process.
 ///
-/// Specific processess can be targeted by optionally via PID. When no PID is
+/// Specific processes can be optionally targeted via their PID. When no PID is
 /// specified, operation is executed for the calling process.
 /// This method can be used to retrieve either a system or an user unit identifier.
 pub fn get_unit(unit_type: UnitType, pid: Option<pid_t>) -> Result<String> {
@@ -26,4 +26,20 @@ pub fn get_unit(unit_type: UnitType, pid: Option<pid_t>) -> Result<String> {
     };
     let unit_name = unsafe { MString::from_raw(c_unit_name) };
     Ok(unit_name.unwrap().to_string())
+}
+
+/// Determines the slice (either in system or user session) of a process.
+///
+/// Specific processes can be optionally targeted via their PID. When no PID is
+/// specified, operation is executed for the calling process.
+/// This method can be used to retrieve either a system or an user slice identifier.
+pub fn get_slice(slice_type: UnitType, pid: Option<pid_t>) -> Result<String> {
+    let mut c_slice_name: *mut c_char = ptr::null_mut();
+    let p: pid_t = pid.unwrap_or(0);
+    match slice_type {
+        UnitType::UserUnit => sd_try!(ffi::sd_pid_get_user_slice(p, &mut c_slice_name)),
+        UnitType::SystemUnit => sd_try!(ffi::sd_pid_get_slice(p, &mut c_slice_name))
+    };
+    let slice_id = unsafe { MString::from_raw(c_slice_name) };
+    Ok(slice_id.unwrap().to_string())
 }

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -31,3 +31,16 @@ fn test_get_slice() {
         true => { assert!(ss.is_ok() || us.is_ok()); },
     };
 }
+
+#[test]
+fn test_get_machine_name() {
+    let mname = login::get_machine_name(None);
+    let has_systemd = booted();
+    assert!(has_systemd.is_ok());
+    match has_systemd.unwrap() {
+        // No machined registration
+        false => { assert!(mname.is_err()); },
+        // This is unpredictable, based on testing environment
+        true => { },
+    };
+}

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -8,12 +8,26 @@ fn test_get_unit() {
     let uu = login::get_unit(login::UnitType::UserUnit, None);
     let su = login::get_unit(login::UnitType::SystemUnit, None);
     let has_systemd = booted();
-    if has_systemd.is_ok() {
-        match has_systemd.unwrap() {
-            // This is not running in an unit at all
-            false => { assert!(uu.is_err()); assert!(su.is_err()); },
-            // This is either running in a system or in an user unit
-            true => { assert_eq!(uu.is_err(), su.is_ok()); },
-        };
-    }
+    assert!(has_systemd.is_ok());
+    match has_systemd.unwrap() {
+        // This is not running in an unit at all
+        false => { assert!(uu.is_err()); assert!(su.is_err()); },
+        // This is either running in a system or in an user unit
+        true => { assert_eq!(uu.is_err(), su.is_ok()); },
+    };
+}
+
+#[test]
+fn test_get_slice() {
+    let us = login::get_slice(login::UnitType::UserUnit, None);
+    let ss = login::get_slice(login::UnitType::SystemUnit, None);
+    let has_systemd = booted();
+    assert!(has_systemd.is_ok());
+    match has_systemd.unwrap() {
+        // This is running in the top-level generic slice
+        false => { assert_eq!(ss.unwrap(), "-.slice"); },
+        // This is running in a system slice, and perhaps
+        // in an user one too
+        true => { assert!(ss.is_ok() || us.is_ok()); },
+    };
 }

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -44,3 +44,16 @@ fn test_get_machine_name() {
         true => { },
     };
 }
+
+#[test]
+fn test_get_cgroup() {
+    let cg = login::get_cgroup(None);
+    let has_systemd = booted();
+    assert!(has_systemd.is_ok());
+    match has_systemd.unwrap() {
+        // Running under systemd, inside a slice somewhere
+        true => { assert!(cg.is_ok()) },
+        // Nothing meaningful to check here
+        false => { },
+    };
+}


### PR DESCRIPTION
This PR introduces wrappers for some more getters from `sd-login`, namely:
 * `get_slice()`
 * `get_cgroup()`
 * `get_machine_name()`

with meaningful testing (as far as possible).
I also spotted a couple of typos in my previous PR, which are fixed here "en passant".