### PR TITLE
journal: use CString for FFI cursor strings

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -2,6 +2,7 @@ use libc::{c_char, c_int, size_t};
 use log::{self, Log, LogRecord, LogLocation, LogLevelFilter, SetLoggerError};
 use std::{fmt, io, ptr, result};
 use std::collections::BTreeMap;
+use std::ffi::CString;
 use std::io::ErrorKind::InvalidData;
 use std::os::raw::c_void;
 use ffi::array_to_iovecs;
@@ -195,7 +196,8 @@ impl Journal {
                 sd_try!(ffi::sd_journal_seek_realtime_usec(self.j, usec))
             }
             JournalSeek::Cursor { cursor } => {
-                sd_try!(ffi::sd_journal_seek_cursor(self.j, cursor.as_ptr() as *const c_char))
+                let c = try!(CString::new(cursor));
+                sd_try!(ffi::sd_journal_seek_cursor(self.j, c.as_ptr()))
             }
         };
         let c: *mut c_char = ptr::null_mut();

--- a/tests/journal.rs
+++ b/tests/journal.rs
@@ -70,6 +70,11 @@ fn test_seek() {
     assert_eq!(c1.unwrap(), c2.unwrap());
     assert!(j.seek(journal::JournalSeek::Tail).is_ok());
     assert!(j.next_record().is_ok());
+    let c3 = j.cursor().unwrap();
+    let valid_cursor = journal::JournalSeek::Cursor { cursor: c3 };
+    assert!(j.seek(valid_cursor).is_ok());
+    let invalid_cursor = journal::JournalSeek::Cursor { cursor: "".to_string() };
+    assert!(j.seek(invalid_cursor).is_err());
 }
 
 #[test]
@@ -96,6 +101,7 @@ fn test_simple_match() {
 
     // check for negative matches
     assert!(j.seek(journal::JournalSeek::Tail).is_ok());
+    assert!(j.match_flush().unwrap().match_add("NOKEY", "NOVALUE").is_ok());
     journal::send(&[&msg]);
     assert!(j.next_record().unwrap().is_none());
 }


### PR DESCRIPTION
This ensures that cursor strings passed to sd-journal FFI are valid
NUL-terminated C string.

Fixes #20