### PR TITLE
Added previous_record, modified next_record

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -176,7 +176,7 @@ impl Journal {
         Ok(journal)
     }
 
-    /// Get the currently selected entry from the journal
+    /// Get and parse the currently journal record from the journal
     fn get_record(&mut self) -> Result<Option<JournalRecord>> {
         unsafe { ffi::sd_journal_restart_data(self.j) }
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -176,12 +176,8 @@ impl Journal {
         Ok(journal)
     }
 
-    /// Read the next record from the journal. Returns `Ok(None)` if there
-    /// are no more records to read.
-    pub fn next_record(&mut self) -> Result<Option<JournalRecord>> {
-        if sd_try!(ffi::sd_journal_next(self.j)) == 0 {
-            return Ok(None);
-        }
+    /// Get the currently selected entry from the journal
+    fn get_record(&mut self) -> Result<Option<JournalRecord>> {
         unsafe { ffi::sd_journal_restart_data(self.j) }
 
         let mut ret: JournalRecord = BTreeMap::new();
@@ -200,6 +196,25 @@ impl Journal {
         }
 
         Ok(Some(ret))
+    }
+
+    /// Read the next record from the journal. Returns `Ok(None)` if there
+    /// are no more records to read.
+    pub fn next_record(&mut self) -> Result<Option<JournalRecord>> {
+        if sd_try!(ffi::sd_journal_next(self.j)) == 0 {
+            return Ok(None);
+        }
+
+        self.get_record()
+        
+    }
+
+    pub fn previous_record(&mut self) -> Result<Option<JournalRecord>> {
+        if sd_try!(ffi::sd_journal_previous(self.j)) == 0 {
+            return Ok(None);
+        }
+        
+        self.get_record()
     }
 
     /// Seek to a specific position in journal. On success, returns a cursor


### PR DESCRIPTION
This Pull Request adds a new function `previous_record` to `systemd::journal::Journal`, which returns the previous journal entry. Its mostly identical to `next_record` (therefor I moved most ob `next_record` to ´get_record`)