### PR TITLE
RFC: Implement waiting for recs using sd_journal_wait

### DIFF
--- a/libsystemd-sys/src/journal.rs
+++ b/libsystemd-sys/src/journal.rs
@@ -9,6 +9,11 @@ pub const SD_JOURNAL_RUNTIME_ONLY: c_int = 2;
 pub const SD_JOURNAL_SYSTEM: c_int = 4;
 pub const SD_JOURNAL_CURRENT_USER: c_int = 8;
 
+// Wakeup event types
+pub const SD_JOURNAL_NOP: c_int = 0;
+pub const SD_JOURNAL_APPEND: c_int = 1;
+pub const SD_JOURNAL_INVALIDATE: c_int = 2;
+
 use id128::sd_id128_t;
 pub enum sd_journal {}
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -256,12 +256,12 @@ impl Journal {
     pub fn await_next_record(&mut self, wait_time: JournalWait) -> Result<Option<JournalRecord>> {
         match self.wait(wait_time)? {
             JournalWaitResult::Nop => Ok(None),
-            JournalWaitResult::Append => self.get_record(),
+            JournalWaitResult::Append => self.next_record(),
 
             // This is possibly wrong, but I can't generate a scenario with 
             // ..::Invalidate and neither systemd's journalctl, 
             // systemd-journal-upload, and other utilities handle that case.
-            JournalWaitResult::Invalidate => self.get_record()
+            JournalWaitResult::Invalidate => self.next_record()
         }
     }
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -265,8 +265,8 @@ impl Journal {
 
     /// Iterate through all elements from the current cursor, then await the
     /// next record(s) and wait again.
-    pub fn watch_all_elements<F>(&mut self, f: F) -> Result<()>
-        where F: Fn(JournalRecord) -> Result<()> {
+    pub fn watch_all_elements<F>(&mut self, mut f: F) -> Result<()>
+        where F: FnMut(JournalRecord) -> Result<()> {
             fn try_and_try<F,A>(mut f: F) -> Result<A>
                 where F: FnMut() -> Result<Option<A>> {
                     loop {

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -126,6 +126,7 @@ pub struct Journal {
 }
 
 /// Represents the set of journal files to read.
+#[derive(Clone, Debug)]
 pub enum JournalFiles {
     /// The system-wide journal.
     System,
@@ -152,6 +153,7 @@ pub enum JournalSeek {
     },
 }
 
+#[derive(Clone, Debug)]
 pub enum JournalWaitResult {
     Nop,
     Append,


### PR DESCRIPTION
Also includes a convenience function to consume all records starting from
the cursor position.