### PR TITLE
daemon: fix lifetime for pointer passed to ffi::sd_is_socket_unix

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -147,16 +147,16 @@ pub fn is_socket_unix<S: CStrArgument>(fd: Fd,
                       listening: Listening,
                       path: Option<S>)
                       -> Result<bool> {
+    let path_cstr = path.map(|p| p.into_cstr());
     let c_socktype = get_c_socktype(socktype);
     let c_listening = get_c_listening(listening);
     let c_path: *const c_char;
     let c_length: size_t;
-    match path {
+    match path_cstr.as_ref() {
         Some(p) => {
-            let path = p.into_cstr();
-            let path_cstr = path.as_ref();
-            c_length = path_cstr.to_bytes().len() as size_t;
-            c_path = path_cstr.as_ptr() as *const c_char;
+            let path_ref = p.as_ref();
+            c_length = path_ref.to_bytes().len() as size_t;
+            c_path = path_ref.as_ptr() as *const c_char;
         }
         None => {
             c_path = ptr::null();


### PR DESCRIPTION
Thanks for the quick turn-around on the uid_t fix, now for a slightly trickier issue. Happy to write tests / do whatever testing is appropriate, but this is working locally for me.

Previously `p.into_cstr()` was used inside a match arm to create an owned cstr which then went out of scope and was dropped before being used later in the ffi call. The borrow checker misses this because the escape from the variable lifetime is done through a raw pointer the checker does not track.

This change creates the owned string in the same scope as it is used so the raw pointer can be obtained and used without issue.

I'm not super happy about using map into an Option to do this, but it was the cleanest way I could think of with my limited Rust knowledge.

Thanks in advance!