### PR TITLE
cargo: be stricter with dependency versions (for 0.1.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ include = ["Cargo.toml", "**/*.rs", "README.md" ]
 bus = ["libsystemd-sys/bus"]
 
 [dependencies]
-log = "0.*"
-libc = "0.*"
-utf8-cstr = "0.*"
-mbox = "0.*"
+log = "~0.3"
+libc = "~0.2"
+utf8-cstr = "~0.1"
+mbox = "~0.4"
 
 [dependencies.libsystemd-sys]
 path = "libsystemd-sys"


### PR DESCRIPTION
Updates from 0.x to 0.y can be breaking changes. Require manual review
before accepting newer minor version bumps.

---
This would be nice to have to fix 0.1.0.

Fixes #44 