### PR TITLE
cargo: be stricter with dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ include = ["Cargo.toml", "src/**/*.rs", "tests/**/*.rs", "README.md" ]
 bus = ["libsystemd-sys/bus"]
 
 [dependencies]
-log = "0.*"
-libc = "0.*"
-utf8-cstr = "0.*"
-mbox = "0.*"
-cstr-argument = "0.0"
+log = "~0.3"
+libc = "~0.2"
+utf8-cstr = "~0.1"
+mbox = "~0.4"
+cstr-argument = "~0.0"
 
 [dependencies.libsystemd-sys]
 path = "libsystemd-sys"


### PR DESCRIPTION
Updates from 0.x to 0.y can be breaking changes. Require manual review
before accepting newer minor version bumps.

---
#39 except applicable to `master`.