### PR TITLE
readme: recommend depending via ~0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git = "https://github.com/jmesmon/rust-systemd"
 Or
 ```toml
 [dependencies]
-systemd = "0.*"
+systemd = "~0.2"
 ```
 
 journal


### PR DESCRIPTION
---
Using `0.*` only works if `rust-systemd` is never going to break API for the 0 series. If that's the case, then maybe a 1.x is in store? ;)