### PR TITLE
No more mbox.  Safer code.  Don't error on improper UTF8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ bus = ["libsystemd-sys/bus"]
 log = "~0.4"
 libc = "~0.2"
 utf8-cstr = "~0.1"
-mbox = "~0.4"
 cstr-argument = "~0.0"
 
 [dependencies.libsystemd-sys]


### PR DESCRIPTION
* `mbox` does not build on nightly at the moment.  This PR gets rid of mbox as a dependency.
* In the previous code, if any of the string pointers returned by ffi were null, this would cause unsafe memory corruption since mbox never checks if the pointer is null.  With this PR, it's a safe panic instead.
* Most of these strings, like machine name for instance, probably don't have any guarantees that they're encoded in UTF8.  Rather than completely failing outright, it's usually recommended to replace invalid unicode characters with the unicode replacement characters and continue.  This is what `from_utf8_lossy` does.