### PR TITLE
Fix memory unsafety in the case of invalid UTF8 journal entries

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -205,7 +205,7 @@ impl Journal {
         while sd_try!(ffi::sd_journal_enumerate_data(self.j, &data, &mut sz)) > 0 {
             unsafe {
                 let b = ::std::slice::from_raw_parts_mut(data, sz as usize);
-                let field = ::std::str::from_utf8_unchecked(b);
+                let field = String::from_utf8_lossy(b);
                 let mut name_value = field.splitn(2, '=');
                 let name = name_value.next().unwrap();
                 let value = name_value.next().unwrap();


### PR DESCRIPTION
This is a rebase of @bvinc 's PR so that bors runs. I'm planning on merging this for now (even though further work on the API is needed), as noded in #47 