### PR TITLE
Fix docs for JournalFiles::All

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -130,7 +130,7 @@ pub enum JournalFiles {
     System,
     /// The current user's journal.
     CurrentUser,
-    /// Both the system-wide journal and the current user's journal.
+    /// All journal files, including other users'.
     All,
 }
 


### PR DESCRIPTION
See: https://github.com/systemd/systemd/blob/878f2dae77e61ee6765b72318f49f8226f45ec0f/src/journal/sd-journal.c#L1192-L1215

`SD_JOURNAL_SYSTEM` filters on `system*`, and `SD_JOURNAL_CURRENT_USER` on `user-{uid}*`, but no flags selects *all* files.