### PR TITLE
journal: add monotonic_timestamp() and other fixes

### DIFF
--- a/src/id128.rs
+++ b/src/id128.rs
@@ -57,3 +57,9 @@ impl PartialEq for Id128 {
         self.inner.bytes == other.inner.bytes
     }
 }
+
+impl Clone for Id128 {
+    fn clone(&self) -> Self {
+        Id128 { inner: ffi::id128::sd_id128_t { bytes: self.inner.bytes.clone() } }
+    }
+}

--- a/src/id128.rs
+++ b/src/id128.rs
@@ -45,4 +45,15 @@ impl Id128 {
     pub fn as_bytes(&self) -> &[u8; 16] {
         &self.inner.bytes
     }
+
+    // Keep this private to the crate since we don't want to expose another crate's type here.
+    pub(crate) fn from_ffi(id: ffi::id128::sd_id128_t) -> Id128 {
+        Id128 { inner: id }
+    }
+}
+
+impl PartialEq for Id128 {
+    fn eq(&self, other: &Id128) -> bool {
+        self.inner.bytes == other.inner.bytes
+    }
 }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -316,7 +316,7 @@ impl Journal {
         Ok(cs)
     }
 
-    /// Returns the cursor of current journal entry
+    /// Returns the cursor of current journal entry.
     pub fn cursor(&self) -> Result<String> {
         let mut c_cursor: *mut c_char = ptr::null_mut();
 
@@ -325,7 +325,7 @@ impl Journal {
         Ok(cursor)
     }
 
-    /// Returns timestamp at which current journal is recorded
+    /// Returns timestamp at which current journal entry is recorded.
     pub fn timestamp(&self) -> Result<time::SystemTime> {
         let mut timestamp_us: u64 = 0;
         sd_try!(ffi::sd_journal_get_realtime_usec(self.j, &mut timestamp_us));

--- a/tests/journal.rs
+++ b/tests/journal.rs
@@ -5,6 +5,7 @@ extern crate log;
 
 use std::path::Path;
 use systemd::journal;
+use systemd::id128;
 
 // Some systems don't have a running journal, which causes our tests to fail currently
 //
@@ -55,6 +56,13 @@ fn ts() {
     log!(log::Level::Info, "rust-systemd test_seek entry");
     assert!(j.seek(journal::JournalSeek::Head).is_ok());
     let _s = j.timestamp().unwrap();
+    assert!(j.seek(journal::JournalSeek::Tail).is_ok());
+    let (u1, entry_boot_id) = j.monotonic_timestamp().unwrap();
+    assert!(u1 > 0);
+    let boot_id = id128::Id128::from_boot().unwrap();
+    assert!(boot_id == entry_boot_id);
+    let u2 = j.monotonic_timestamp_current_boot().unwrap();
+    assert_eq!(u1, u2);
 }
 
 


### PR DESCRIPTION
See individual commit messages for details, the primary one being the second commit:

This function is not only useful for the timestamp itself, but also for
retrieving the boot ID of the current journal entry. IIUC, this is *not*
equivalent to the `_BOOT_ID` entry field, which may not be matched
properly in some cases. For more details, see:
systemd/systemd@dc00966

Implementation-wise, there's nothing surprising here. It's a
straightforward wrapper of the underlying API.  Also implement
`From<ffi::id128::sd_id128_t>` for `Id128` to convert to the wrapper
type from the ffi type and `PartialEq` to help testing (but which I also
need for my use case).