### PR TITLE
id128: add a default null constructor

### DIFF
--- a/src/id128.rs
+++ b/src/id128.rs
@@ -1,11 +1,16 @@
-use std::mem::uninitialized;
-use std::fmt;
+//! APIs to process and generate 128-bit ID values for systemd.
+//!
+//! These ID values are a generalization of OSF UUIDs but use a
+//! simpler string format. See `man 3 sd-id128` for more details.
+
+use super::Result;
 use ffi;
 use std::ffi::CStr;
-use super::Result;
+use std::fmt;
 
+/// A 128-bit ID for systemd.
 pub struct Id128 {
-    inner: ffi::id128::sd_id128_t,
+    pub(crate) inner: ffi::id128::sd_id128_t,
 }
 
 impl fmt::Display for Id128 {
@@ -17,38 +22,42 @@ impl fmt::Display for Id128 {
     }
 }
 
+impl Default for Id128 {
+    /// Return a null-ID, consisting of only NUL bytes.
+    fn default() -> Self {
+        Id128 {
+            inner: ffi::id128::sd_id128_t { bytes: [0x00; 16] },
+        }
+    }
+}
+
 impl Id128 {
     pub fn from_cstr(s: &CStr) -> Result<Id128> {
-        let mut r: Id128 = unsafe { uninitialized() };
+        let mut r = Id128::default();
         sd_try!(ffi::id128::sd_id128_from_string(s.as_ptr(), &mut r.inner));
         Ok(r)
     }
 
     pub fn from_random() -> Result<Id128> {
-        let mut r: Id128 = unsafe { uninitialized() };
+        let mut r = Id128::default();
         sd_try!(ffi::id128::sd_id128_randomize(&mut r.inner));
         Ok(r)
     }
 
     pub fn from_machine() -> Result<Id128> {
-        let mut r: Id128 = unsafe { uninitialized() };
+        let mut r = Id128::default();
         sd_try!(ffi::id128::sd_id128_get_machine(&mut r.inner));
         Ok(r)
     }
 
     pub fn from_boot() -> Result<Id128> {
-        let mut r: Id128 = unsafe { uninitialized() };
+        let mut r = Id128::default();
         sd_try!(ffi::id128::sd_id128_get_boot(&mut r.inner));
         Ok(r)
     }
 
     pub fn as_bytes(&self) -> &[u8; 16] {
         &self.inner.bytes
-    }
-
-    // Keep this private to the crate since we don't want to expose another crate's type here.
-    pub(crate) fn from_ffi(id: ffi::id128::sd_id128_t) -> Id128 {
-        Id128 { inner: id }
     }
 }
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -4,7 +4,6 @@ use std::{io, ptr, result, fmt};
 use std::collections::BTreeMap;
 use std::ffi::CString;
 use std::io::ErrorKind::InvalidData;
-use std::mem::uninitialized;
 use std::os::raw::c_void;
 use std::u64;
 use ffi::array_to_iovecs;
@@ -344,13 +343,13 @@ impl Journal {
     /// Returns monotonic timestamp and boot ID at which current journal entry is recorded.
     pub fn monotonic_timestamp(&self) -> Result<(u64, Id128)> {
         let mut monotonic_timestamp_us: u64 = 0;
-        let mut id: sd_id128_t = unsafe { uninitialized() };
+        let mut id = Id128::default();
         sd_try!(ffi::sd_journal_get_monotonic_usec(
             self.j,
             &mut monotonic_timestamp_us,
-            &mut id,
+            &mut id.inner,
         ));
-        Ok((monotonic_timestamp_us, Id128::from_ffi(id)))
+        Ok((monotonic_timestamp_us, id))
     }
 
     /// Returns monotonic timestamp at which current journal entry is recorded. Returns an error if

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,6 @@ macro_rules! sd_journal_log{
 /// High-level interface to the systemd daemon module.
 pub mod daemon;
 
-/// API for working with 128-bit ID values, which are a generalizastion of OSF UUIDs (see `man 3
-/// sd-id128` for details
 pub mod id128;
 
 /// Interface to introspect on seats, sessions and users.


### PR DESCRIPTION
This introduces a default null-ID constructor for Id128 (similar to
`SD_ID128_NULL`) and removes a few unsafe uninitialized initializations.