### PR TITLE
Implement `Debug` for Id128, derive `Clone` and `Debug` for `JournalSeek`

### DIFF
--- a/src/id128.rs
+++ b/src/id128.rs
@@ -13,6 +13,12 @@ pub struct Id128 {
     pub(crate) inner: ffi::id128::sd_id128_t,
 }
 
+impl fmt::Debug for Id128 {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        <Self as fmt::Display>::fmt(self, fmt)
+    }
+}
+
 impl fmt::Display for Id128 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         for b in self.inner.bytes.iter() {

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -135,6 +135,7 @@ pub enum JournalFiles {
 }
 
 /// Seeking position in journal.
+#[derive(Clone, Debug)]
 pub enum JournalSeek {
     Head,
     Current,


### PR DESCRIPTION
Let me know if this isn't interesting -- I ran into a case where it'd be nice to include `JournalSeek` as a `Debug` rather than a `Display`. For `Id128`, it rarely makes sense to have `Display` but not `Debug`! :)