### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -25,7 +25,7 @@ fn test_notify() {
     let result = daemon::notify(false, [
         (daemon::STATE_READY, "1"),
         (daemon::STATE_STATUS, "Running test_notify()"),
-    ].into_iter());
+    ].iter());
     assert!(result.is_ok());
     assert_eq!(result.ok().unwrap(), false); // should fail, since this is not systemd-launched.
 }


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
