### PR TITLE
systemd::Journal::open_files corrected

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ utf8-cstr = "~0.1"
 cstr-argument = "~0.1"
 #enumflags2 = "^0.5"
 #enumflags2_derive = "^0.5"
+serde = { version = "1.0", default-features = false, features=["derive"], optional = true}
 
 [dependencies.libsystemd-sys]
 path = "libsystemd-sys"

--- a/examples/journal-logger.rs
+++ b/examples/journal-logger.rs
@@ -18,7 +18,7 @@ fn main() {
     // Open the journal
     let runtime_only = false;
     let local_only = false;
-    let mut reader = Journal::open(JournalFiles::All, runtime_only, local_only)
+    let mut reader = Journal::open(&JournalFiles::All, runtime_only, local_only)
         .expect("Could not open journal");
 
     // Seek to end of current log to prevent old messages from being printed

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -109,6 +109,7 @@ fn system_time_from_realtime_usec(usec: u64) -> time::SystemTime {
 }
 
 // A single log entry from journal.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub type JournalRecord = BTreeMap<String, String>;
 
 /// A reader for systemd journal.
@@ -124,6 +125,7 @@ unsafe impl Send for Journal {}
 
 /// Represents the set of journal files to read.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum JournalFiles {
     /// The system-wide journal.
     System,

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -172,7 +172,7 @@ impl Journal {
     ///   boot. If false, include all entries.
     /// * local_only: if true, include only journal entries originating from
     ///   localhost. If false, include all entries.
-    pub fn open(files: JournalFiles, runtime_only: bool, local_only: bool) -> Result<Journal> {
+    pub fn open(files: &JournalFiles, runtime_only: bool, local_only: bool) -> Result<Journal> {
         let mut flags: c_int = 0;
         if runtime_only {
             flags |= ffi::SD_JOURNAL_RUNTIME_ONLY;
@@ -205,7 +205,7 @@ impl Journal {
     /// * os_root: if true, journal files are searched for below the usual
     ///   /var/log/journal and /run/log/journal relative to the specified path,
     ///   instead of directly beneath it.
-    pub fn open_directory(path: &std::path::Path, files: JournalFiles, os_root: bool) -> Result<Journal> {
+    pub fn open_directory(path: &std::path::Path, files: &JournalFiles, os_root: bool) -> Result<Journal> {
         let c_path = CString::new(path.to_str().unwrap()).unwrap();
         let mut flags: c_int = 0;
         if os_root {

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -223,20 +223,16 @@ impl Journal {
         Ok(journal)
     }
 
-    /// Open the systemd journal located in a specific folder for reading.
+    /// Open the systemd journal located in a a list of files for reading. 
+    /// "Please note that in the case of a live journal, this function is only 
+    /// useful for debugging, because individual journal files can be rotated at
+    /// any moment, and the opening of specific files is inherently racy."
     ///
     /// Params:
     ///
     /// * path: the absolute directory path. All journal files in this directory
     ///   will be opened and interleaved automatically.
-    /// * files: the set of journal files to read. If the calling process
-    ///   doesn't have permission to read the system journal, a call to
-    ///   `Journal::open` with `System` or `All` will succeed, but system
-    ///   journal entries won't be included. This behavior is due to systemd.
-    /// * os_root: if true, journal files are searched for below the usual
-    ///   /var/log/journal and /run/log/journal relative to the specified path,
-    ///   instead of directly beneath it.
-    pub fn open_files(paths: &std::vec::Vec<&std::path::Path>, flags: JournalFiles, os_root: bool) -> Result<Journal> {
+    pub fn open_files(paths: &std::vec::Vec<&std::path::Path>) -> Result<Journal> {
         let mut c_paths: Vec<std::rc::Rc<CString>> = std::vec::Vec::new();
         let mut c_paths_ptr: Vec<*const c_char> = std::vec::Vec::new();
         for path in paths {
@@ -245,16 +241,8 @@ impl Journal {
             c_paths_ptr.push(c_path.as_ptr());
         }
         c_paths_ptr.push(ptr::null_mut());
-        // let c_path = CString::new(path.to_str().unwrap()).unwrap();
         let mut c_flags: c_int = 0;
-        if os_root {
-            c_flags |= ffi::SD_JOURNAL_OS_ROOT;
-        }
-        c_flags |= match flags {
-            JournalFiles::System => ffi::SD_JOURNAL_SYSTEM,
-            JournalFiles::CurrentUser => ffi::SD_JOURNAL_CURRENT_USER,
-            JournalFiles::All => 0
-        };
+
         let mut journal = Journal { j: ptr::null_mut() };
         sd_try!(ffi::sd_journal_open_files(&mut journal.j, c_paths_ptr.as_ptr(), c_flags));
         sd_try!(ffi::sd_journal_seek_head(journal.j));

--- a/tests/journal.rs
+++ b/tests/journal.rs
@@ -40,7 +40,7 @@ fn cursor() {
         return;
     }
 
-    let mut j = journal::Journal::open(journal::JournalFiles::All, false, false).unwrap();
+    let mut j = journal::Journal::open(&journal::JournalFiles::All, false, false).unwrap();
     log!(log::Level::Info, "rust-systemd test_seek entry");
     assert!(j.seek(journal::JournalSeek::Head).is_ok());
     let _s = j.cursor().unwrap();
@@ -52,7 +52,7 @@ fn ts() {
         return;
     }
 
-    let mut j = journal::Journal::open(journal::JournalFiles::All, false, false).unwrap();
+    let mut j = journal::Journal::open(&journal::JournalFiles::All, false, false).unwrap();
     log!(log::Level::Info, "rust-systemd test_seek entry");
     assert!(j.seek(journal::JournalSeek::Head).is_ok());
     let _s = j.timestamp().unwrap();
@@ -68,7 +68,7 @@ fn ts() {
 
 #[test]
 fn test_seek() {
-    let mut j = journal::Journal::open(journal::JournalFiles::All, false, false).unwrap();
+    let mut j = journal::Journal::open(&journal::JournalFiles::All, false, false).unwrap();
     if ! have_journal() {
         return;
     }
@@ -95,10 +95,11 @@ fn test_simple_match() {
         return;
     }
     let key = "RUST_TEST_MARKER";
+
     let value = "RUST_SYSTEMD_SIMPLE_MATCH";
     let msg = "MESSAGE=rust-systemd test_match";
     let filter = format!("{}={}", key, value);
-    let mut j = journal::Journal::open(journal::JournalFiles::All, false, false).unwrap();
+    let mut j = journal::Journal::open(&journal::JournalFiles::All, false, false).unwrap();
 
     // check for positive matches
     assert!(j.seek(journal::JournalSeek::Tail).is_ok());


### PR DESCRIPTION
I made some minor adjustments on systemd::journal::Journal.open_files(). The API offers flags which I initially implemented in Rust as well. But the documentation clearly states, that these flags are ignored. Since that is not temporarily but (due to technical limitations) permanently, I adjusted the Rust implementation to skip the flags (its just confusing!).

The documentation was incorrect as well. I fixed that too.