### PR TITLE
Add elogind support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
-
 name = "systemd"
 version = "0.4.0"
 authors = ["Cody P Schafer <dev@codyps.com>"]
 license = "LGPL-2.1+"
-description = "A rust interface to libsystemd provided APIs"
+description = "A rust interface to libsystemd/libelogind provided APIs"
 repository = "https://github.com/jmesmon/rust-systemd"
 documentation = "https://docs.rs/systemd"
 include = ["Cargo.toml", "src/**/*.rs", "tests/**/*.rs", "README.md" ]
 
 [features]
 bus = ["libsystemd-sys/bus"]
+elogind = ["libsystemd-sys/elogind"]
 
 [dependencies]
 log = "~0.4"

--- a/libsystemd-sys/Cargo.toml
+++ b/libsystemd-sys/Cargo.toml
@@ -4,7 +4,7 @@ name = "libsystemd-sys"
 version = "0.2.2"
 authors = ["Cody P Schafer <dev@codyps.com>"]
 license = "LGPL-2.1+"
-description = "FFI bindings to libsystemd"
+description = "FFI bindings to libsystemd and libelogind"
 repository = "https://github.com/jmesmon/rust-systemd"
 include = ["Cargo.toml", "**/*.rs", "build.rs" ]
 documentation = "https://docs.rs/libsystemd-sys"
@@ -14,6 +14,7 @@ build = "build.rs"
 
 [features]
 bus = []
+elogind = []
 
 [dependencies]
 libc = "0.*"

--- a/libsystemd-sys/build.rs
+++ b/libsystemd-sys/build.rs
@@ -2,21 +2,41 @@ extern crate pkg_config;
 use std::env;
 
 fn main() {
-    let e = match pkg_config::find_library("libsystemd") {
+    #[cfg(not(feature = "elogind"))]
+    let library = pkg_config::find_library("libsystemd");
+    #[cfg(feature = "elogind")]
+    let library = pkg_config::find_library("libelogind");
+
+    let error = match library {
         Ok(_) => return,
-        Err(e) => e,
+        Err(error) => error,
     };
 
-    match env::var("LIBSYSTEMD_LDFLAGS") {
+    #[cfg(not(feature = "elogind"))]
+    let ld_preload_var = "LIBSYSTEMD_LDFLAGS";
+    #[cfg(feature = "elogind")]
+    let ld_preload_var = "LIBELOGIND_LDFLAGS";
+
+    match env::var(ld_preload_var) {
         Ok(flags) => {
             /* Ideally we'd avoid rustc-flags in favor of rustc-link-{search,lib}, but this should
              * work fine
              */
-            println!("cargo:rustc-flags={}", flags);
+            eprintln!("cargo:rustc-flags={}", flags);
         }
         Err(_) => {
-            println!("{}", e);
-            panic!("systemd was not found via pkg-config nor via the env var LIBSYSTEMD_LDFLAGS")
-        },
+            eprintln!("{}", error);
+
+            #[cfg(not(feature = "elogind"))]
+            let lib_name = "systemd";
+
+            #[cfg(feature = "elogind")]
+            let lib_name = "elogind";
+
+            panic!(
+                "{} was not found via pkg-config nor via the env var {}",
+                lib_name, ld_preload_var
+            );
+        }
     }
 }

--- a/libsystemd-sys/src/daemon.rs
+++ b/libsystemd-sys/src/daemon.rs
@@ -17,6 +17,8 @@ extern "C" {
                              path: *const c_char,
                              length: size_t)
                              -> c_int;
+    // On elogind it always returns error.
+    #[cfg(not(feature = "elogind"))]
     pub fn sd_is_mq(fd: c_int, path: *const c_char) -> c_int;
     pub fn sd_notify(unset_environment: c_int, state: *const c_char) -> c_int;
     // skipping sd_*notifyf; ignoring format strings

--- a/libsystemd-sys/src/lib.rs
+++ b/libsystemd-sys/src/lib.rs
@@ -14,6 +14,7 @@ pub use std::os::raw::{c_char, c_int, c_void, c_uint};
 pub mod id128;
 pub mod event;
 pub mod daemon;
+#[cfg(not(feature = "elogind"))]
 pub mod journal;
 pub mod login;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -147,11 +147,7 @@ pub fn is_socket_inet(fd: Fd,
 }
 
 pub fn tcp_listener(fd: Fd) -> Result<TcpListener> {
-    if !try!(is_socket_inet(fd,
-                            None,
-                            Some(SocketType::Stream),
-                            Listening::IsListening,
-                            None)) {
+    if !is_socket_inet(fd, None, Some(SocketType::Stream), Listening::IsListening, None)? {
         Err(Error::new(ErrorKind::InvalidInput, "Socket type was not as expected"))
     } else {
         Ok(unsafe { TcpListener::from_raw_fd(fd) })
@@ -190,6 +186,7 @@ pub fn is_socket_unix<S: CStrArgument>(fd: Fd,
 
 /// Identifies whether the passed file descriptor is a POSIX message queue. If a
 /// path is supplied, it will also verify the name.
+#[cfg(not(feature = "elogind"))]
 pub fn is_mq<S: CStrArgument>(fd: Fd, path: Option<S>) -> Result<bool> {
     let path = path.map(|x| x.into_cstr());
     let result = sd_try!(ffi::sd_is_mq(fd, path.map_or(null(), |x| x.as_ref().as_ptr())));

--- a/src/id128.rs
+++ b/src/id128.rs
@@ -22,7 +22,7 @@ impl fmt::Debug for Id128 {
 impl fmt::Display for Id128 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         for b in self.inner.bytes.iter() {
-            try!(write!(fmt, "{:02x}", b));
+            write!(fmt, "{:02x}", b)?;
         }
         Ok(())
     }

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -375,7 +375,7 @@ impl Journal {
                 sd_try!(ffi::sd_journal_seek_realtime_usec(self.j, usec))
             }
             JournalSeek::Cursor { cursor } => {
-                let c = try!(CString::new(cursor));
+                let c = CString::new(cursor)?;
                 sd_try!(ffi::sd_journal_seek_cursor(self.j, c.as_ptr()))
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate enumflags2_derive;
 
 use libc::{c_char, c_void, free, strlen};
 pub use std::io::{Result, Error};
+#[cfg(not(feature = "elogind"))]
 pub use journal::{Journal, JournalFiles, JournalLog, JournalRecord, JournalSeek, JournalWaitResult};
 
 
@@ -54,7 +55,7 @@ fn free_cstring(ptr: *mut c_char) -> Option<String> {
 #[macro_export]
 macro_rules! sd_try {
     ($e:expr) => ({
-        try!($crate::ffi_result(unsafe{ $e}))
+        $crate::ffi_result(unsafe{ $e})?
     })
 }
 
@@ -62,6 +63,7 @@ macro_rules! sd_try {
 ///
 /// The main interface for writing to the journal is `fn log()`, and the main
 /// interface for reading the journal is `struct Journal`.
+#[cfg(not(feature = "elogind"))]
 pub mod journal;
 
 /// Similar to `log!()`, except it accepts a func argument rather than hard
@@ -92,6 +94,7 @@ macro_rules! log_with{
     })
 }
 
+#[cfg(not(feature = "elogind"))]
 #[macro_export]
 macro_rules! sd_journal_log{
     ($lvl:expr, $($arg:tt)+) => (log_with!(@raw ::systemd::journal::log, $lvl, $($arg)+))


### PR DESCRIPTION
libelogind exposes identical interface to libsystemd, except some minor
parts like journal (it just has stubs for them afaisc).

Since libelogind has subset of libsystemd APIs, and since their C API is identical, I guess it makes sense to have support for it in this crate. Doing so will naturally bring support for elogind based systems for downstream projects like https://github.com/smithay/smithay and so they can launch on them just by activating a feature flag without changing their code, unless they are using journal API.

This was tested on elogind based system in smithay and worked fine. I' not sure if docs should be changed much, I've adjusted some though.