### PR TITLE
make features adative (remove elogind, add journal)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md" ]
 edition = "2018"
 
 [features]
+default = ["bus", "journal"]
+
 bus = ["libsystemd-sys/bus"]
-elogind = ["libsystemd-sys/elogind"]
-default = ["bus"]
+journal = ["libsystemd-sys/journal"]
 
 [dependencies]
 log = "~0.4"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,36 @@ Or
 systemd = { git = "https://github.com/jmesmon/rust-systemd" }
 ```
 
+Build Environment variables
+---------------------------
+
+By default, `libsystemd-sys` will use `pkg-config` to find `libsystemd`. It
+defaults to using the `systemd` package. To change the package looked up in
+pkg-config, set the `SYSTEMD_PKG_NAME` environment variable.
+
+If you want to override the source of the `libsystemd` directly, set the env
+var `SYSTEMD_LIB_DIR` to a path which contains the `libsystemd` to link
+against. Optionally, you may also set `SYSTEMD_LIBS` to indicate which
+libraries to link against. Libraries in the variable `SYSTEMD_LIBS` are colon
+(`:`) seperated and may include a `KIND`. For example:
+`SYSTEMD_LIBS="static=foo:bar"`.
+
+
+elogind support
+---------------
+
+Either set `SYSTEMD_PKG_NAME=elogind` or set both `SYSTEMD_LIBS=elogind` and
+set `SYSTEMD_LIB_DIR` to the appropriate directory.
+
+When using elogind, the apis needed for `journal` and `bus` features are not
+avaliable. If your application does not need these features, depend on
+`systemd` this way to allow it to be used with elogind:
+
+```toml
+[dependencies]
+systemd = { version = "0.4", default-features = false }
+```
+
 journal
 -------
 Journal sending is supported, and systemd::journal::Journal is a (low

--- a/libsystemd-sys/Cargo.toml
+++ b/libsystemd-sys/Cargo.toml
@@ -12,6 +12,8 @@ edition = "2018"
 build = "build.rs"
 
 [features]
+default = ["bus"]
+
 bus = []
 elogind = []
 

--- a/libsystemd-sys/Cargo.toml
+++ b/libsystemd-sys/Cargo.toml
@@ -12,10 +12,10 @@ edition = "2018"
 build = "build.rs"
 
 [features]
-default = ["bus"]
+default = ["bus", "journal"]
 
 bus = []
-elogind = []
+journal = []
 
 [dependencies]
 libc = "0.2.76"

--- a/libsystemd-sys/build.rs
+++ b/libsystemd-sys/build.rs
@@ -40,7 +40,7 @@ fn main() {
     match libs {
         Some(libs) => {
             //let libs = libs.expect(&format!("non utf-8 value provided in {}", lib_var));
-            for lib in libs.into_string().unwrap().split(":") {
+            for lib in libs.into_string().unwrap().split(':') {
                 println!("cargo:rustc-link={}", lib);
             }
         }

--- a/libsystemd-sys/src/bus/vtable.rs
+++ b/libsystemd-sys/src/bus/vtable.rs
@@ -2,6 +2,7 @@ use std::mem::{transmute, zeroed};
 use std::default::Default;
 use super::super::{c_char, size_t};
 use super::{sd_bus_message_handler_t, sd_bus_property_get_t, sd_bus_property_set_t};
+use c2rust_bitfields::BitfieldStruct;
 
 // XXX: check this repr, might vary based on platform type sizes
 #[derive(Clone,Copy,Debug)]
@@ -18,6 +19,7 @@ pub enum SdBusVtableType {
 #[derive(Clone, Copy, Debug)]
 #[repr(u64)]
 pub enum SdBusVtableFlag {
+    #[allow(clippy::identity_op)]
     Deprecated = 1 << 0,
     Hidden = 1 << 1,
     Unprivileged = 1 << 2,

--- a/libsystemd-sys/src/bus/vtable.rs
+++ b/libsystemd-sys/src/bus/vtable.rs
@@ -2,7 +2,6 @@ use std::mem::{transmute, zeroed};
 use std::default::Default;
 use super::super::{c_char, size_t};
 use super::{sd_bus_message_handler_t, sd_bus_property_get_t, sd_bus_property_set_t};
-use c2rust_bitfields::BitfieldStruct;
 
 // XXX: check this repr, might vary based on platform type sizes
 #[derive(Clone,Copy,Debug)]

--- a/libsystemd-sys/src/daemon.rs
+++ b/libsystemd-sys/src/daemon.rs
@@ -17,8 +17,6 @@ extern "C" {
                              path: *const c_char,
                              length: size_t)
                              -> c_int;
-    // On elogind it always returns error.
-    #[cfg(not(feature = "elogind"))]
     pub fn sd_is_mq(fd: c_int, path: *const c_char) -> c_int;
     pub fn sd_notify(unset_environment: c_int, state: *const c_char) -> c_int;
     // skipping sd_*notifyf; ignoring format strings

--- a/libsystemd-sys/src/lib.rs
+++ b/libsystemd-sys/src/lib.rs
@@ -10,7 +10,7 @@ pub use std::os::raw::{c_char, c_int, c_void, c_uint};
 pub mod id128;
 pub mod event;
 pub mod daemon;
-#[cfg(not(feature = "elogind"))]
+#[cfg(feature = "journal")]
 pub mod journal;
 pub mod login;
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -186,7 +186,6 @@ pub fn is_socket_unix<S: CStrArgument>(fd: Fd,
 
 /// Identifies whether the passed file descriptor is a POSIX message queue. If a
 /// path is supplied, it will also verify the name.
-#[cfg(not(feature = "elogind"))]
 pub fn is_mq<S: CStrArgument>(fd: Fd, path: Option<S>) -> Result<bool> {
     let path = path.map(|x| x.into_cstr());
     let result = sd_try!(ffi::sd_is_mq(fd, path.map_or(null(), |x| x.as_ref().as_ptr())));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate enumflags2_derive;
 
 use libc::{c_char, c_void, free, strlen};
 pub use std::io::{Result, Error};
-#[cfg(not(feature = "elogind"))]
+#[cfg(feature = "journal")]
 pub use journal::{Journal, JournalFiles, JournalLog, JournalRecord, JournalSeek, JournalWaitResult};
 
 
@@ -58,7 +58,7 @@ macro_rules! sd_try {
 ///
 /// The main interface for writing to the journal is `fn log()`, and the main
 /// interface for reading the journal is `struct Journal`.
-#[cfg(not(feature = "elogind"))]
+#[cfg(feature = "journal")]
 pub mod journal;
 
 /// Similar to `log!()`, except it accepts a func argument rather than hard
@@ -89,7 +89,7 @@ macro_rules! log_with{
     })
 }
 
-#[cfg(not(feature = "elogind"))]
+#[cfg(feature = "journal")]
 #[macro_export]
 macro_rules! sd_journal_log{
     ($lvl:expr, $($arg:tt)+) => (log_with!(@raw ::systemd::journal::log, $lvl, $($arg)+))


### PR DESCRIPTION
For features to work right, they need to be adative. IOW: enabling
features can only _extend_ the API.

elogind does not support the journal apis, so instead provide that as a
feature.

Also, remove the elogind behavior from the build.rs script and document
the use of environment variables to control the build instead.

In the future, we could consider having our build.rs try to link with
elogind when systemd is absent (and features permit it?).