### PR TITLE
journal: expose more direct interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
 dependencies = [
  "unicode-xid",
 ]
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d8d6567fe7c7f8835a3a98af4208f3846fba258c1bc3c31d6e506239f11f9"
+checksum = "963f7d3cc59b59b9325165add223142bbf1df27655d07789f109896d353d8350"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -204,6 +204,7 @@ dependencies = [
  "libc",
  "libsystemd-sys",
  "log",
+ "memchr",
  "serde",
  "utf8-cstr",
  "version-sync",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ journal = ["libsystemd-sys/journal"]
 [dependencies]
 log = "~0.4"
 libc = "~0.2"
+memchr = "2.3.3"
 utf8-cstr = "~0.1"
 cstr-argument = "~0.1"
 foreign-types = "0.5.0"

--- a/README.md
+++ b/README.md
@@ -34,14 +34,18 @@ elogind support
 Either set `SYSTEMD_PKG_NAME=elogind` or set both `SYSTEMD_LIBS=elogind` and
 set `SYSTEMD_LIB_DIR` to the appropriate directory.
 
-When using elogind, the apis needed for `journal` and `bus` features are not
-avaliable. If your application does not need these features, depend on
-`systemd` this way to allow it to be used with elogind:
+When using elogind, the apis needed for `journal` and `bus` features may not be completely
+avaliable (elogind forked from an older version of systemd that may lack some
+of these APIs). If your application does not need these features, depend on
+`systemd` without the default features to allow maximum compatibility:
 
 ```toml
 [dependencies]
 systemd = { version = "0.5", default-features = false }
 ```
+
+Note that there still may be some missing symbols. If you discover a link
+error, report it so that we can tweak the `systemd` crate to support it.
 
 journal
 -------

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 rust-systemd
 ============
 
-[Documentation](http://codyps.com/docs/systemd/x86_64-unknown-linux-gnu/stable/systemd/index.html)
+[crate docs (systemd)](http://docs.rs/crate/systemd)
+[crate docs (libsystemd-sys)](http://docs.rs/crate/libsystemd-sys)
 [![Crates.io](https://img.shields.io/crates/v/systemd.svg?maxAge=2592000)](https://crates.io/crates/systemd)
-[![Clippy Linting Result](https://clippy.bashy.io/github/jmesmon/rust-systemd/master/badge.svg)](https://clippy.bashy.io/github/jmesmon/rust-systemd/master/log)
 [![Build Status](https://travis-ci.org/jmesmon/rust-systemd.svg?branch=master)](https://travis-ci.org/jmesmon/rust-systemd)
 
 

--- a/libsystemd-sys/src/bus/vtable.rs
+++ b/libsystemd-sys/src/bus/vtable.rs
@@ -52,9 +52,7 @@ impl sd_bus_vtable {
 
         val[0] = typ as u8;
         let flags_raw: [u8; 8] = unsafe { transmute(flags) };
-        for i in 0..7 {
-            val[i + 1] = flags_raw[i];
-        }
+        val[1..(7 + 1)].clone_from_slice(&flags_raw[..7]);
 
         unsafe { transmute(val) }
     }
@@ -75,7 +73,7 @@ impl sd_bus_vtable {
         unsafe {
             let raw: *const u8 = transmute(&self.type_and_flags);
             for i in 1..8 {
-                val[i - 1] = *raw.offset(i as isize);
+                val[i - 1] = *raw.add(i);
             }
             transmute(val)
         }

--- a/libsystemd-sys/src/id128.rs
+++ b/libsystemd-sys/src/id128.rs
@@ -1,7 +1,9 @@
 use super::{c_char, c_int};
 
+/// Note: this is marked `Copy` because the libsystemd apis pass it by value without implying an
+/// ownership transfer.
 #[repr(C)]
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct sd_id128_t {
     pub bytes: [u8; 16],
 }

--- a/src/id128.rs
+++ b/src/id128.rs
@@ -8,7 +8,7 @@ use std::ffi::CStr;
 use std::fmt;
 
 /// A 128-bit ID for systemd.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Id128 {
     pub(crate) inner: ffi::id128::sd_id128_t,
 }


### PR DESCRIPTION
 - removes our juggling with iteration around seeking. user is now
   required to iterate themselves
 - adds direct access to the fields of a journal entry rather than only
   having them in the mixed iteration/allocate btreemap functions
   (next_entry, etc)
 - Drops `Current` as a seek location, it's a noop that exists to call
   `sd_journal_next()` in a roundabout way that no longer makes sense
 - remove journal seeking from the journal opening. all our tests
   already explicitly seek. I expect everything else is likely to do
   this as well. It also makes our interface more direct

Fixes #31, Fixes #91
