### PR TITLE
ci: remove rustfmt from travis, rely on gha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ rust:
   - beta
   - nightly
 
-install:
-  - rustup component add rustfmt
-
 script:
   - ci/script
 


### PR DESCRIPTION
 - travis builds for stable, beta, and nightly
 - nightly sometimes doesn't have a rustfmt component
 - we already only run rustfmt (`cargo fmt`) in github actions (fmt.yml)
 - avoid installing it at all on travis