### PR TITLE
journal: make wait() public 

### DIFF
--- a/examples/journal-reader.rs
+++ b/examples/journal-reader.rs
@@ -1,0 +1,68 @@
+#[cfg(feature = "journal")]
+mod x {
+    //! Follow future journal log messages and print up to 100 of them.
+    use systemd::journal::{Journal, JournalFiles, JournalSeek};
+
+    const KEY_UNIT: &str = "_SYSTEMD_UNIT";
+    const KEY_MESSAGE: &str = "MESSAGE";
+
+    const MAX_MESSAGES: usize = 100;
+
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+        println!("Starting journal-logger");
+
+        // Open the journal
+        let runtime_only = false;
+        let local_only = false;
+        let mut reader = Journal::open(JournalFiles::All, runtime_only, local_only)
+            .expect("Could not open journal");
+
+        // Seek to end of current log to prevent old messages from being printed
+        reader
+            .seek(JournalSeek::Tail)
+            .expect("Could not seek to end of journal");
+
+        // Print up to MAX_MESSAGES incoming messages
+        let mut i = 0;
+        loop {
+            loop {
+                if reader.next()? == 0 {
+                    break;
+                }
+
+                let unit: Option<_> = reader.get_data(KEY_UNIT)?.and_then(|v| {
+                    v.value()
+                        .map(String::from_utf8_lossy)
+                        .map(|v| v.into_owned())
+                });
+                let message = reader.get_data(KEY_MESSAGE)?.and_then(|v| {
+                    v.value()
+                        .map(String::from_utf8_lossy)
+                        .map(|v| v.into_owned())
+                });
+
+                println!("[{:?}] {:?}", unit, message);
+
+                i += 1;
+                if i >= MAX_MESSAGES {
+                    eprintln!("done.");
+                    return Ok(());
+                }
+            }
+
+            reader.wait(None)?;
+        }
+    }
+}
+
+#[cfg(not(feature = "journal"))]
+mod x {
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+        println!("pass `--features journal`");
+        Ok(())
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    x::main()
+}

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -560,7 +560,7 @@ impl Journal {
     /// Using a `wait_time` of `None` will wait for an unlimited period for new entries.
     ///
     /// Corresponds to `sd_journal_wait()`.
-    fn wait(&mut self, wait_time: Option<time::Duration>) -> Result<JournalWaitResult> {
+    pub fn wait(&mut self, wait_time: Option<time::Duration>) -> Result<JournalWaitResult> {
         let time = wait_time.map(usec_from_duration).unwrap_or(u64::MAX);
 
         match sd_try!(ffi::sd_journal_wait(self.as_ptr(), time)) {


### PR DESCRIPTION
The existing interfaces don't quite work right. Give folks access to the
actual systemd interface.

Also add an example of using the low-level journal interfaces to stream data.