### PR TITLE
fix all clippy warnings and check in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ on:
     branches-ignore:
       - '**.tmp'
 
-name: code formatting
+name: check
 
 jobs:
-  fmt:
+  check:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,9 +17,14 @@ jobs:
           profile: minimal
           toolchain: beta
           override: true
-          components: rustfmt
+          components: rustfmt, clippy
 
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
 	"continuous-integration/travis-ci/push",
-	"fmt"
+	"check"
 ]
 cut_body_after = "---"
 delete_merged_branches = true

--- a/src/bus/types.rs
+++ b/src/bus/types.rs
@@ -163,7 +163,7 @@ impl<'a> FromSdBusMessage<'a> for UnixFd {
     where
         Self: Sized,
     {
-        unsafe { m.read_basic_raw(b'h', |x: c_int| UnixFd(x)) }
+        unsafe { m.read_basic_raw(b'h', UnixFd) }
     }
 }
 

--- a/src/journal.rs
+++ b/src/journal.rs
@@ -489,16 +489,11 @@ impl Journal {
 
         self.restart_data();
 
-        loop {
-            match self.enumerate_data()? {
-                Some(d) => {
-                    ret.insert(
-                        String::from_utf8_lossy(d.name()).into(),
-                        String::from_utf8_lossy(d.value().unwrap()).into(),
-                    );
-                }
-                None => break,
-            }
+        while let Some(d) = self.enumerate_data()? {
+            ret.insert(
+                String::from_utf8_lossy(d.name()).into(),
+                String::from_utf8_lossy(d.value().unwrap()).into(),
+            );
         }
 
         Ok(ret)
@@ -507,6 +502,8 @@ impl Journal {
     /// Iterate over journal entries.
     ///
     /// Corresponds to `sd_journal_next()`
+    // TODO: consider renaming
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Result<u64> {
         crate::ffi_result(unsafe { ffi::sd_journal_next(self.as_ptr()) })
             .map(|v| v.try_into().unwrap())
@@ -626,7 +623,7 @@ impl Journal {
     /// Corresponds to `sd_journal_seek_monotonic_usec()`
     pub fn seek_monotonic_usec(&mut self, boot_id: Id128, usec: u64) -> Result<()> {
         crate::ffi_result(unsafe {
-            ffi::sd_journal_seek_monotonic_usec(self.as_ptr(), boot_id.as_raw().clone(), usec)
+            ffi::sd_journal_seek_monotonic_usec(self.as_ptr(), *boot_id.as_raw(), usec)
         })?;
 
         Ok(())


### PR DESCRIPTION
This does add a few directed suppressions around
`clippy::should_implement_trait`. We have functions named `next()` on a
few of our types. These can't quite be translated to `Iterator` impls.
Seems like it could make sense to rename them.