### PR TITLE
ci: build and test on gha too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: ci
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install dependencies
+        run: sudo apt install libsystemd-dev pkgconf
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ on:
     branches-ignore:
       - '**.tmp'
 
-name: check
+name: ci
 
 jobs:
-  check:
+  ci:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,6 +18,16 @@ jobs:
           toolchain: beta
           override: true
           components: rustfmt, clippy
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all --verbose --all-features
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --verbose --all-features
 
       - uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "build-env"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e068f31938f954b695423ecaf756179597627d0828c0d3e48c0a722a8b23cf9e"
+checksum = "6cf89846ef2b2674ef1c153256cec98fba587c72bf4ea2c4b2f6d91a19f55926"
 
 [[package]]
 name = "cfg-if"

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
 	"continuous-integration/travis-ci/push",
-	"check"
+	"ci"
 ]
 cut_body_after = "---"
 delete_merged_branches = true

--- a/libsystemd-sys/Cargo.toml
+++ b/libsystemd-sys/Cargo.toml
@@ -22,4 +22,4 @@ libc = "0.2.76"
 
 [build-dependencies]
 pkg-config = "0.3.18"
-build-env = "0.2.0"
+build-env = "0.3.0"

--- a/libsystemd-sys/build.rs
+++ b/libsystemd-sys/build.rs
@@ -29,11 +29,15 @@ fn main() {
             let library = pkg_config::find_library(&library_name);
 
             match library {
-                Ok(_) => return,
-                Err(error) => eprintln!("pkg_config could not find {:?}: {}", library_name, error),
+                Ok(_) => {
+                    // pkg-config says it has it, so we'll trust it to have done the right thing
+                    return;
+                }
+                Err(error) => {
+                    eprintln!("pkg_config could not find {:?}: {}", library_name, error);
+                    std::process::exit(1);
+                }
             };
-
-            return;
         }
     };
 

--- a/libsystemd-sys/tests/journal-send.rs
+++ b/libsystemd-sys/tests/journal-send.rs
@@ -1,0 +1,12 @@
+use libsystemd_sys as sd;
+
+#[test]
+fn raw_send() {
+    let a = ["MESSAGE=raw rust-systemd send"];
+    let v = [sd::const_iovec {
+        iov_base: a[0].as_ptr() as *const _,
+        iov_len: a[0].len(),
+    }];
+    let r = unsafe { sd::journal::sd_journal_sendv(v.as_ptr(), v.len() as std::os::raw::c_int) };
+    assert!(r >= 0);
+}


### PR DESCRIPTION
travis (with our building of libsystemd, etc) is very slow. one option to speed things up is to use github actions more extensively (what this pr does).

Alternately, there are some changes in travis that might help (like going to a version of ubuntu that doesn't require us to build libsystemd)