### PR TITLE
use :: to disambiguate `use`

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -4,8 +4,8 @@
 /// [libsystemd](https://crates.io/crates/libsystemd) crate, and you may prefer to use it instead.
 use super::ffi::{c_int, pid_t, size_t};
 use super::{Error, Result};
+use ::ffi::daemon as ffi;
 use cstr_argument::CStrArgument;
-use ffi::daemon as ffi;
 use libc::{c_char, c_uint};
 use libc::{SOCK_DGRAM, SOCK_RAW, SOCK_STREAM};
 use std::io::ErrorKind;

--- a/src/login.rs
+++ b/src/login.rs
@@ -1,7 +1,7 @@
 use super::ffi::{c_char, c_uint, pid_t, uid_t};
 use super::{free_cstring, Result};
+use ::ffi::login as ffi;
 use cstr_argument::CStrArgument;
-use ffi::login as ffi;
 use std::ptr;
 
 /// Systemd slice and unit types


### PR DESCRIPTION
Without this, rustc 1.48 (as of now, rustc nightly-2020-10-04) is
expected to fail to build rust-systemd.

Rustc issue: https://github.com/rust-lang/rust/issues/77586