### PR TITLE
libsystemd-sys/build: actually bail out if pkg-config fails and env overrides are not used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: check
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: Install libsystemd-dev
+        run: sudo apt-get install libsystemd-dev
+
       - uses: actions-rs/cargo@v1
         with:
           command: fmt

--- a/libsystemd-sys/build.rs
+++ b/libsystemd-sys/build.rs
@@ -29,11 +29,15 @@ fn main() {
             let library = pkg_config::find_library(&library_name);
 
             match library {
-                Ok(_) => return,
-                Err(error) => eprintln!("pkg_config could not find {:?}: {}", library_name, error),
+                Ok(_) => {
+                    // pkg-config says it has it, so we'll trust it to have done the right thing
+                    return;
+                }
+                Err(error) => {
+                    eprintln!("pkg_config could not find {:?}: {}", library_name, error);
+                    std::process::exit(1);
+                }
             };
-
-            return;
         }
     };
 


### PR DESCRIPTION
Without this, systems lacking libsystemd result in annoying link errors.