### PR TITLE
libsystemd-sys: fix cargo directive for library to link

### DIFF
--- a/libsystemd-sys/build.rs
+++ b/libsystemd-sys/build.rs
@@ -57,11 +57,11 @@ fn main() {
         Some(libs) => {
             //let libs = libs.expect(&format!("non utf-8 value provided in {}", lib_var));
             for lib in libs.into_string().unwrap().split(':') {
-                println!("cargo:rustc-link={}", lib);
+                println!("cargo:rustc-link-lib={}", lib);
             }
         }
         None => {
-            println!("cargo:rustc-link={}", name);
+            println!("cargo:rustc-link-lib={}", name);
         }
     }
 }


### PR DESCRIPTION
fixes #149