### PR TITLE
license: add GCC-exception-2.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,8 +19,10 @@ jobs:
           override: true
           components: rustfmt, clippy
 
+      - name: apg-get update
+        run: sudo apt-get -o Acquire::Retries=3 update
       - name: Install libsystemd-dev
-        run: sudo apt-get install libsystemd-dev
+        run: sudo apt-get -o Acquire::Retries=3 install libsystemd-dev
 
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -18,8 +18,10 @@ jobs:
           toolchain: beta
           override: true
 
+      - name: apg-get update
+        run: sudo apt-get -o Acquire::Retries=3 update
       - name: Install libsystemd-dev
-        run: sudo apt-get install libsystemd-dev
+        run: sudo apt-get -o Acquire::Retries=3 install libsystemd-dev
 
       - name: Check with no-default-features
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "systemd"
 version = "0.7.1"
 authors = ["Cody P Schafer <dev@codyps.com>"]
-license = "LGPL-2.1-or-later"
+license = "LGPL-2.1-or-later WITH GCC-exception-2.0"
 description = "A rust interface to libsystemd/libelogind provided APIs"
 repository = "https://github.com/jmesmon/rust-systemd"
 documentation = "https://docs.rs/crate/systemd"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ modify it under the terms of the GNU Lesser General Public
 License as published by the Free Software Foundation; either
 version 2.1 of the License, or (at your option) any later version.
 
+In addition to the permissions in the GNU Lesser General Public License, the
+authors give you unlimited permission to link the compiled version of this
+library into combinations with other programs, and to distribute those programs
+without any restriction coming from the use of this library. (The Lesser
+General Public License restrictions do apply in other respects; for example,
+they cover modification of the library, and distribution when not linked into
+another program.)
+
 This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
@@ -95,13 +103,5 @@ Contributions
 -------------
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you shall be dual licensed as above, without any
-additional terms or conditions. You also agree to apply the following exception:
-
-In addition to the permissions in the GNU Lesser General Public License, the
-authors give you unlimited permission to link the compiled version of this
-library into combinations with other programs, and to distribute those programs
-without any restriction coming from the use of this library. (The Lesser
-General Public License restrictions do apply in other respects; for example,
-they cover modification of the library, and distribution when not linked into
-another program.)
+for inclusion in the work by you shall be licensed as above, without any
+additional terms or conditions.

--- a/libsystemd-sys/Cargo.toml
+++ b/libsystemd-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "libsystemd-sys"
 version = "0.7.1"
 authors = ["Cody P Schafer <dev@codyps.com>"]
-license = "LGPL-2.1-or-later"
+license = "LGPL-2.1-or-later WITH GCC-exception-2.0"
 description = "FFI bindings to libsystemd and libelogind"
 repository = "https://github.com/jmesmon/rust-systemd"
 include = ["Cargo.toml", "**/*.rs", "build.rs" ]


### PR DESCRIPTION
All code included in rust-systemd that was not relicensed by the
contributors has either been removed, or corresponds to
non-copyrightable elements (direct translation of C api definitions into
rust).

The new code was written without reference to the removed code

Closes #92 and closes #127

Thanks everyone for your help on this!