### PR TITLE
In open_with_opts_files, iterate through file_cstrs by reference to…

### DIFF
--- a/src/journal.rs
+++ b/src/journal.rs
@@ -578,7 +578,7 @@ impl Journal {
         }
 
         let mut file_ptrs = Vec::new();
-        for i in file_cstrs {
+        for i in &file_cstrs {
             file_ptrs.push(i.as_ref().as_ptr());
         }
 


### PR DESCRIPTION
In open_with_opts_files, iterate through file_cstrs by reference to avoid string contents from being deallocated

I was using the rust-systemd lib, and it seemed like systemd was having trouble connecting to files using `OpenFilesOptions`, always returning a NotFound error when trying to open a connection.  After some debugging, it looks like the data pointed to by the file name char* values turns to garbage at some point before being passed to the `sd_journal_open_files` function.  Iterating through `file_cstrs` by reference seems to solve the problem by preventing the contents from being moved/consumed by the for loop.