### PR TITLE
remove explicit lifetime so clippy is happy

### DIFF
--- a/src/bus/mod.rs
+++ b/src/bus/mod.rs
@@ -1818,7 +1818,7 @@ impl MessageRef {
     ///
     /// Requires that message is sealed.
     #[inline]
-    pub fn iter<'a>(&'a mut self) -> crate::Result<MessageIter<'a>> {
+    pub fn iter(&mut self) -> crate::Result<MessageIter<'_>> {
         /* probe the `Message` to check if we can iterate on it */
         sd_try!(ffi::bus::sd_bus_message_peek_type(
             self.as_ptr(),


### PR DESCRIPTION
```
warning: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
    --> src/bus/mod.rs:1821:5
     |
1821 |     pub fn iter<'a>(&'a mut self) -> crate::Result<MessageIter<'a>> {
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(clippy::needless_lifetimes)]` on by default
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes

warning: 1 warning emitted
```