### PR TITLE
Return custom struct, iterable struct from sd_listen_fds

### DIFF
--- a/examples/socket-activation.rs
+++ b/examples/socket-activation.rs
@@ -39,12 +39,12 @@ fn handle_client(mut stream: TcpStream) {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let lfds = daemon::listen_fds(false).unwrap_or(0);
-    if lfds != 1 {
-        panic!("Must have exactly 1 fd to listen on, got {}", lfds);
+    let lfds = daemon::listen_fds(false)?;
+    if lfds.len() != 1 {
+        panic!("Must have exactly 1 fd to listen on, got {}", lfds.len());
     }
 
-    let listener = daemon::tcp_listener(daemon::LISTEN_FDS_START).unwrap();
+    let listener = daemon::tcp_listener(lfds.iter().next().unwrap()).unwrap();
 
     // accept connections and process them serially
     for stream in listener.incoming() {

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -4,7 +4,7 @@ use systemd::daemon;
 
 #[test]
 fn test_listen_fds() {
-    assert_eq!(daemon::listen_fds(false).ok().unwrap(), 0);
+    assert!(daemon::listen_fds(false).ok().unwrap().is_empty());
 }
 
 #[test]


### PR DESCRIPTION
The documentation and the type of dameon::listen_fds didn't seem to
match.  The type is Fd, but it is used as an integer.  While this isn't
technically a problem, it's a little confusing to read.  This is my
attempt to provide something more useful, and perhaps easier to use
correctly.

This adds two structs: ListenFds and ListenFdsRange.  The first is
returned by listen_fds if assuming there isn't an error.  The second is
returned by the first's iter() method.  This allow for a way to access
multiple file descriptors if they happen to be returned.