### PR TITLE
Update journal logging interface

### DIFF
--- a/libsystemd-sys/src/journal.rs
+++ b/libsystemd-sys/src/journal.rs
@@ -1,8 +1,7 @@
 #![allow(non_camel_case_types)]
 
-use super::const_iovec;
 use super::size_t;
-use super::{c_char, c_int, c_void};
+use super::{c_char, c_int, c_void, const_iovec};
 
 pub const SD_JOURNAL_LOCAL_ONLY: c_int = 1 << 0;
 pub const SD_JOURNAL_RUNTIME_ONLY: c_int = 1 << 1;


### PR DESCRIPTION
This started out as a way of trying to reduce the number of allocations
made by the log_record function.  It was making allocations during:

1. The construction of each of the strings.
2. The initial construction of the vector
3. Potentially one or two more for the subsequent push calls
4. The construction of the AsRef vector
5. The construction of the const_iovec in the array_to_iovecs function

This reduces it to:
1. The construction of each of the strings.
2. The construction of the vector of const_iovec

However, as a result of looking at these interfaces, I noticed a couple
of things.  First was that the libsystemd-sys crate was defining an
iovec struct that's a duplicate of the libc::iovec struct.  I removed
this and just pub-defined the libc version.

The second is that array_to_iovecs is hiding some inherently unsafe
functionality by capturing a pointer to the base of a buffer.  I removed
this function and added an unsafe from_str function to construct it.
Given that the systemd interface requires an array of const iovecs as
input, I don't see a good way to create something that correctly manages
the lifetimes, without making it inordinately inflexible.