### PR TITLE
app-specific ids for machine and boot

### DIFF
--- a/libsystemd-sys/src/id128.rs
+++ b/libsystemd-sys/src/id128.rs
@@ -19,5 +19,7 @@ extern "C" {
 
     pub fn sd_id128_randomize(ret: *mut sd_id128_t) -> c_int;
     pub fn sd_id128_get_machine(ret: *mut sd_id128_t) -> c_int;
+    pub fn sd_id128_get_machine_app_specific(app_id: sd_id128_t, ret: *mut sd_id128_t) -> c_int;
     pub fn sd_id128_get_boot(ret: *mut sd_id128_t) -> c_int;
+    pub fn sd_id128_get_boot_app_specific(app_id: sd_id128_t, ret: *mut sd_id128_t) -> c_int;
 }

--- a/src/id128.rs
+++ b/src/id128.rs
@@ -58,9 +58,27 @@ impl Id128 {
         Ok(r)
     }
 
+    pub fn from_machine_app_specific(app_id: &Id128) -> Result<Id128> {
+        let mut r = Id128::default();
+        sd_try!(ffi::id128::sd_id128_get_machine_app_specific(
+            *app_id.as_raw(),
+            &mut r.inner
+        ));
+        Ok(r)
+    }
+
     pub fn from_boot() -> Result<Id128> {
         let mut r = Id128::default();
         sd_try!(ffi::id128::sd_id128_get_boot(&mut r.inner));
+        Ok(r)
+    }
+
+    pub fn from_boot_app_specific(app_id: &Id128) -> Result<Id128> {
+        let mut r = Id128::default();
+        sd_try!(ffi::id128::sd_id128_get_boot_app_specific(
+            *app_id.as_raw(),
+            &mut r.inner
+        ));
         Ok(r)
     }
 


### PR DESCRIPTION
systemd docs state that machine id and boot id should remain
confidential, and provide _app_specific variants of these two functions
to securely hash it against a 128-bit application id.