### PR TITLE
Add feature flag for systemd version 245

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,15 @@ edition = "2018"
 [features]
 default = ["bus", "journal"]
 
+full = [
+  "bus",
+  "journal",
+  "systemd_v245"
+]
+
 bus = ["libsystemd-sys/bus"]
 journal = ["libsystemd-sys/journal"]
+systemd_v245 = ["libsystemd-sys/systemd_v245"]
 
 [dependencies]
 log = "~0.4"
@@ -37,3 +44,7 @@ doc-comment = "0.3"
 
 [profile.release]
 debug = true
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,6 @@ edition = "2018"
 [features]
 default = ["bus", "journal"]
 
-full = [
-  "bus",
-  "journal",
-  "systemd_v245"
-]
-
 bus = ["libsystemd-sys/bus"]
 journal = ["libsystemd-sys/journal"]
 systemd_v245 = ["libsystemd-sys/systemd_v245"]

--- a/libsystemd-sys/Cargo.toml
+++ b/libsystemd-sys/Cargo.toml
@@ -17,6 +17,7 @@ default = ["bus", "journal"]
 
 bus = []
 journal = []
+systemd_v245 = []
 
 [dependencies]
 libc = "0.2.76"

--- a/libsystemd-sys/src/journal.rs
+++ b/libsystemd-sys/src/journal.rs
@@ -26,6 +26,7 @@ extern "C" {
     // (we don't need to do c-style format strings)
 
     pub fn sd_journal_open(ret: *mut *mut sd_journal, flags: c_int) -> c_int;
+    #[cfg(feature = "systemd_v245")]
     pub fn sd_journal_open_namespace(
         ret: *mut *mut sd_journal,
         namespace: *const c_char,


### PR DESCRIPTION
The method `sd_journal_open_namespace` was added in systemd v245 (see the [systemd changelog](https://github.com/systemd/systemd/blob/v245/NEWS#L79-L86)). This version is not yet available in the stable branches of some major Linux distributions, for instance in Debian 10 which contains version 241 (https://packages.debian.org/buster/libsystemd-dev).

This pull request adds the feature flag `systemd_v245`. `sd_journal_open_namespace` is only available if this feature flag is set.

This is the first step to fix issue #132.