### PR TITLE
Fix journal-reader example to point to the most recent entry

### DIFF
--- a/examples/journal-reader.rs
+++ b/examples/journal-reader.rs
@@ -23,6 +23,10 @@ mod x {
             .seek(JournalSeek::Tail)
             .expect("Could not seek to end of journal");
 
+        // JournalSeek::Tail goes to the position after the most recent entry so step back to
+        // point to the most recent entry.
+        reader.previous()?;
+
         // Print up to MAX_MESSAGES incoming messages
         let mut i = 0;
         loop {


### PR DESCRIPTION
If next if called directly after seek tail, a random old entry is pointed.
See the implementation in journalctl:
https://github.com/systemd/systemd/blob/8389fd19d20370077f2d5601af0a089ec92ece05/src/journal/journalctl.c#L1292-L1299

And this related bug report: https://bugs.freedesktop.org/show_bug.cgi?id=64614