### PR TITLE
Fix running tests inside user units

### DIFF
--- a/tests/login.rs
+++ b/tests/login.rs
@@ -15,9 +15,9 @@ fn test_get_unit() {
             assert!(uu.is_err());
             assert!(su.is_err());
         }
-        // This is either running in a system or in a user unit
+        // User units run under a system unit (E.g. user@1000.service)
         true => {
-            assert_eq!(uu.is_err(), su.is_ok());
+            assert!(su.is_ok());
         }
     };
 }


### PR DESCRIPTION
The assertion in `test_get_unit` failed on the assumption that there could only be either a system unit or a user unit, while having both is possible.

For example, in my system every desktop application gets its own user unit (e.g. `app-org.kde.konsole-<SOMEID>.scope`) and this is in turn part of the system unit which owns the user session (e.g. `user@1000.service`).

I'm assuming that every user unit will be part of such a `user@.service` and so I changed the assertion to only verify that condition.